### PR TITLE
Set logs slice length to capacity in InMemoryStore.Clear

### DIFF
--- a/internal/store/memory.go
+++ b/internal/store/memory.go
@@ -95,7 +95,7 @@ func (s *InMemoryStore) Clear() error {
 		return nil
 	}
 
-	s.logs = make([]*model.RequestLog, 0)
+	s.logs = make([]*model.RequestLog, s.capacity)
 	s.size = 0
 	s.next = 0
 	return nil


### PR DESCRIPTION
This PR fixes a bug in the in-memory storage backend of GoVisual related to the Clear() method.

**Problem solved**:
Previously, after calling Clear() on the in-memory store, adding a new request would cause a runtime error: index out of range [0] with length 0. This happened because the logs slice was being reset with zero length, while the store expects the slice to always have a length equal to its capacity.

**Summary of changes**:
- Updated the Clear() method in InMemoryStore to reset s.logs with make([]*model.RequestLog, s.capacity) instead of make([]*model.RequestLog, 0).
- This ensures the internal slice always has the expected length and prevents index out of range errors when adding new requests after clearing.

**Notes**:
If you have any feedback or would like changes to the implementation, please let me know!
Happy to adapt the PR as needed.

## Summary by Sourcery

Bug Fixes:
- Prevent index out of range error when adding new requests after clearing the store by maintaining the slice's expected length