### PR TITLE
Add comprehensive tests for store backends and telemetry initialization

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,53 @@
+name: GoVisual Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: testuser
+          POSTGRES_PASSWORD: testpass
+          POSTGRES_DB: testdb
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.22
+
+      - name: Install SQLite driver (CGO)
+        run: sudo apt-get update && sudo apt-get install -y libsqlite3-dev
+
+      - name: Run tests
+        env:
+          PG_CONN: postgres://testuser:testpass@localhost:5432/testdb?sslmode=disable
+          REDIS_CONN: redis://localhost:6379/0
+        run: go test -v ./...

--- a/internal/middleware/middleware_test.go
+++ b/internal/middleware/middleware_test.go
@@ -1,0 +1,95 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/doganarif/govisual/internal/model"
+)
+
+// mockStore implements store.Store for testing
+type mockStore struct {
+	logs []*model.RequestLog
+}
+
+func (m *mockStore) Add(log *model.RequestLog) {
+	m.logs = append(m.logs, log)
+}
+
+func (m *mockStore) Get(id string) (*model.RequestLog, bool) {
+	for _, log := range m.logs {
+		if log.ID == id {
+			return log, true
+		}
+	}
+	return nil, false
+}
+
+func (m *mockStore) GetAll() []*model.RequestLog {
+	return m.logs
+}
+
+func (m *mockStore) Clear() error {
+	m.logs = nil
+	return nil
+}
+
+func (m *mockStore) GetLatest(n int) []*model.RequestLog {
+	if n >= len(m.logs) {
+		return m.logs
+	}
+	return m.logs[len(m.logs)-n:]
+}
+
+func (m *mockStore) Close() error {
+	return nil
+}
+
+// mockPathMatcher implements PathMatcher
+type mockPathMatcher struct{}
+
+func (m *mockPathMatcher) ShouldIgnorePath(path string) bool {
+	return false
+}
+
+func TestWrapMiddleware(t *testing.T) {
+	store := &mockStore{}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte("hello world"))
+	})
+
+	wrapped := Wrap(handler, store, true, true, &mockPathMatcher{})
+
+	req := httptest.NewRequest("POST", "/test?x=1", strings.NewReader("sample-body"))
+	req.Header.Set("X-Test", "test")
+	rec := httptest.NewRecorder()
+
+	wrapped.ServeHTTP(rec, req)
+
+	if len(store.logs) != 1 {
+		t.Fatalf("expected 1 log entry, got %d", len(store.logs))
+	}
+	log := store.logs[0]
+
+	if log.Method != "POST" {
+		t.Errorf("expected Method POST, got %s", log.Method)
+	}
+	if log.Path != "/test" {
+		t.Errorf("expected Path /test, got %s", log.Path)
+	}
+	if log.RequestBody != "sample-body" {
+		t.Errorf("expected RequestBody to be 'sample-body', got '%s'", log.RequestBody)
+	}
+	if log.ResponseBody != "hello world" {
+		t.Errorf("expected ResponseBody to be 'hello world', got '%s'", log.ResponseBody)
+	}
+	if log.StatusCode != http.StatusCreated {
+		t.Errorf("expected status %d, got %d", http.StatusCreated, log.StatusCode)
+	}
+	if log.Duration < 0 {
+		t.Errorf("expected Duration > 0, got %d", log.Duration)
+	}
+}

--- a/internal/middleware/otel_test.go
+++ b/internal/middleware/otel_test.go
@@ -1,0 +1,60 @@
+package middleware
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestOTelMiddleware_ServeHTTP(t *testing.T) {
+	// Set up a test tracer provider and span recorder
+	sr := sdktrace.NewSimpleSpanProcessor(&testSpanExporter{})
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+	otel.SetTracerProvider(tp)
+
+	// Dummy handler to respond with status
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+		io.WriteString(w, "traced")
+	})
+
+	// Wrap with OTelMiddleware
+	middleware := NewOTelMiddleware(handler, "test-service", "v1.0")
+
+	req := httptest.NewRequest("GET", "/hello", nil)
+	req.Header.Set("User-Agent", "TestClient")
+	rec := httptest.NewRecorder()
+
+	middleware.ServeHTTP(rec, req)
+
+	// Basic output check
+	if rec.Code != http.StatusAccepted {
+		t.Errorf("expected status %d, got %d", http.StatusAccepted, rec.Code)
+	}
+}
+
+// testSpanExporter implements a basic SpanExporter to print spans (you can extend this to assert attributes)
+type testSpanExporter struct{}
+
+func (e *testSpanExporter) ExportSpans(_ context.Context, spans []sdktrace.ReadOnlySpan) error {
+	for _, span := range spans {
+		if span.Name() == "" {
+			panic("span name is empty")
+		}
+		if span.SpanKind() != trace.SpanKindServer {
+			panic("span kind is not server")
+		}
+	}
+	return nil
+}
+
+func (e *testSpanExporter) Shutdown(_ context.Context) error {
+	return nil
+}

--- a/internal/model/request_test.go
+++ b/internal/model/request_test.go
@@ -1,0 +1,41 @@
+package model
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestNewRequestLog(t *testing.T) {
+	req, err := http.NewRequest("POST", "http://localhost:8080/test-path?foo=bar", strings.NewReader("body-content"))
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	req.Header.Set("X-Test-Header", "HeaderValue")
+
+	log := NewRequestLog(req)
+
+	if log.ID == "" {
+		t.Error("expected ID to be generated, got empty string")
+	}
+
+	if log.Method != "POST" {
+		t.Errorf("expected method to be POST, got %s", log.Method)
+	}
+
+	if log.Path != "/test-path" {
+		t.Errorf("expected method to be /test-path, got %s", log.Path)
+	}
+
+	if log.Query != "foo=bar" {
+		t.Errorf("expected query to be foo=bar, got %s", log.Query)
+	}
+
+	if log.RequestHeaders.Get("X-Test-Header") != "HeaderValue" {
+		t.Errorf("expected request header to Header Value, got %s", log.RequestHeaders.Get("X-Test-Header"))
+	}
+
+	if log.Timestamp.IsZero() {
+		t.Errorf("expected timestamp set, got zero value")
+	}
+}

--- a/internal/store/memory_test.go
+++ b/internal/store/memory_test.go
@@ -1,0 +1,10 @@
+package store
+
+import (
+	"testing"
+)
+
+func TestInMemoryStore(t *testing.T) {
+	store := NewInMemoryStore(10)
+	runStoreTests(t, store)
+}

--- a/internal/store/postgres_test.go
+++ b/internal/store/postgres_test.go
@@ -1,0 +1,20 @@
+package store
+
+import (
+	"os"
+	"testing"
+)
+
+func TestPostgresStore(t *testing.T) {
+	connStr := os.Getenv("PG_CONN")
+	if connStr == "" {
+		t.Skip("PG_CONN not set; skipping PostgreSQL test")
+	}
+
+	store, err := NewPostgresStore(connStr, "logs", 10)
+	if err != nil {
+		t.Fatalf("failed to create Postgres store: %v", err)
+	}
+
+	runStoreTests(t, store)
+}

--- a/internal/store/redis_test.go
+++ b/internal/store/redis_test.go
@@ -1,0 +1,20 @@
+package store
+
+import (
+	"os"
+	"testing"
+)
+
+func TestRedisStore(t *testing.T) {
+	connStr := os.Getenv("REDIS_CONN")
+	if connStr == "" {
+		t.Skip("REDIS_CONN not set; skipping Redis test")
+	}
+
+	store, err := NewRedisStore(connStr, 10, 3600)
+	if err != nil {
+		t.Fatalf("failed to create Redis store: %v", err)
+	}
+
+	runStoreTests(t, store)
+}

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -1,0 +1,23 @@
+package store
+
+import (
+	"database/sql"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func TestSQLiteStore(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open sqlite3: %v", err)
+	}
+	defer db.Close()
+
+	store, err := NewSQLiteStoreWithDB(db, "logs", 10)
+	if err != nil {
+		t.Fatalf("failed to create SQLite store: %v", err)
+	}
+
+	runStoreTests(t, store)
+}

--- a/internal/store/store_common_test.go
+++ b/internal/store/store_common_test.go
@@ -1,0 +1,50 @@
+package store
+
+import (
+	"testing"
+	"time"
+
+	"github.com/doganarif/govisual/internal/model"
+)
+
+func runStoreTests(t *testing.T, store Store) {
+	defer store.Clear()
+	defer store.Close()
+
+	// Create a log entry
+	log := &model.RequestLog{
+		ID:         "test-1",
+		Timestamp:  time.Now(),
+		Method:     "GET",
+		Path:       "/test",
+		StatusCode: 200,
+	}
+
+	store.Add(log)
+
+	// Test Get
+	got, ok := store.Get("test-1")
+	if !ok || got.ID != "test-1" {
+		t.Errorf("expected to get log with ID 'test-1', got %+v", got)
+	}
+
+	// Test GetAll
+	all := store.GetAll()
+	if len(all) != 1 {
+		t.Errorf("expected 1 log in GetAll, got %d", len(all))
+	}
+
+	// Test GetLatest
+	latest := store.GetLatest(1)
+	if len(latest) != 1 || latest[0].ID != "test-1" {
+		t.Errorf("expected to get latest log with ID 'test-1', got %+v", latest)
+	}
+
+	// Test Clear
+	if err := store.Clear(); err != nil {
+		t.Errorf("Clear failed: %v", err)
+	}
+	if len(store.GetAll()) != 0 {
+		t.Error("expected no logs after Clear")
+	}
+}


### PR DESCRIPTION
- Added shared test suite for store interface compliance
- Unit tests for:
  - InMemoryStore
  - SQLiteStore (in-memory)
  - RedisStore (requires REDIS_CONN)
  - PostgresStore (requires PG_CONN)
- Safe test for InitTracer with fallback if OTLP collector is unavailable
- GitHub Actions workflow to run tests with Postgres and Redis containers
- Local test support via `act` with GOTOOLCHAIN=local workaround

### 🚧 Notes:
- PG_CONN and REDIS_CONN must be set for Redis/Postgres tests to run
- OTLP collector is optional for telemetry tests — skipped if unavailable

This improves test coverage and CI reliability while preserving dev flexibility.

## Summary by Sourcery

Add comprehensive test suite for store backends and middleware components, improving test coverage and CI reliability

CI:
- Added GitHub Actions workflow to run tests with Postgres and Redis containers
- Configured test environment with support for different database backends

Tests:
- Created shared test suite for store interface compliance
- Added unit tests for InMemoryStore, SQLiteStore, RedisStore, and PostgresStore
- Implemented tests for middleware request logging and OpenTelemetry tracing

Chores:
- Implemented flexible test setup with optional database connection support