### PR TITLE
Fix nested middleware traces being dropped

### DIFF
--- a/internal/middleware/tracer.go
+++ b/internal/middleware/tracer.go
@@ -61,8 +61,8 @@ func (rt *RequestTracer) StartTrace(name, traceType string, details interface{})
 		rt.Traces = append(rt.Traces, entry)
 		rt.currentPath = append(rt.currentPath, len(rt.Traces)-1)
 	} else {
-		// Nested trace
-		parent := rt.getParentTrace()
+		// Nested trace: the entry currentPath points at becomes the parent.
+		parent := rt.getCurrentTrace()
 		if parent != nil {
 			parent.Children = append(parent.Children, entry)
 			rt.currentPath = append(rt.currentPath, len(parent.Children)-1)
@@ -238,26 +238,6 @@ func (rt *RequestTracer) getCurrentTrace() *TraceEntry {
 
 	trace := &rt.Traces[rt.currentPath[0]]
 	for i := 1; i < len(rt.currentPath); i++ {
-		if rt.currentPath[i] >= len(trace.Children) {
-			return nil // Invalid path, cannot traverse further
-		}
-		trace = &trace.Children[rt.currentPath[i]]
-	}
-	return trace
-}
-
-func (rt *RequestTracer) getParentTrace() *TraceEntry {
-	if len(rt.currentPath) <= 1 {
-		return nil
-	}
-
-	// Check if root index is valid
-	if rt.currentPath[0] >= len(rt.Traces) {
-		return nil
-	}
-
-	trace := &rt.Traces[rt.currentPath[0]]
-	for i := 1; i < len(rt.currentPath)-1; i++ {
 		if rt.currentPath[i] >= len(trace.Children) {
 			return nil // Invalid path, cannot traverse further
 		}

--- a/internal/middleware/tracer_test.go
+++ b/internal/middleware/tracer_test.go
@@ -1,0 +1,61 @@
+package middleware
+
+import "testing"
+
+func TestNestedTraces(t *testing.T) {
+	rt := NewRequestTracer("req-1")
+
+	rt.StartTrace("outer", "middleware", nil)
+	rt.StartTrace("inner", "handler", nil)
+	rt.StartTrace("innermost", "custom", nil)
+	rt.EndTrace(nil)
+	rt.EndTrace(nil)
+	rt.EndTrace(nil)
+
+	traces := rt.GetTraces()
+	if len(traces) != 1 {
+		t.Fatalf("expected 1 root trace, got %d", len(traces))
+	}
+
+	outer := traces[0]
+	if outer.Name != "outer" || outer.Status != "completed" {
+		t.Fatalf("root trace = %q (%s), want outer (completed)", outer.Name, outer.Status)
+	}
+	if len(outer.Children) != 1 || outer.Children[0].Name != "inner" {
+		t.Fatalf("outer children = %+v, want [inner]", outer.Children)
+	}
+
+	inner := outer.Children[0]
+	if inner.Status != "completed" {
+		t.Fatalf("inner status = %s, want completed", inner.Status)
+	}
+	if len(inner.Children) != 1 || inner.Children[0].Name != "innermost" {
+		t.Fatalf("inner children = %+v, want [innermost]", inner.Children)
+	}
+}
+
+func TestNestedTraceSiblings(t *testing.T) {
+	rt := NewRequestTracer("req-2")
+
+	rt.StartTrace("root", "handler", nil)
+	rt.StartTrace("step 1", "custom", nil)
+	rt.EndTrace(nil)
+	rt.StartTrace("step 2", "custom", nil)
+	rt.EndTrace(nil)
+	rt.EndTrace(nil)
+
+	traces := rt.GetTraces()
+	if len(traces) != 1 {
+		t.Fatalf("expected 1 root trace, got %d", len(traces))
+	}
+	root := traces[0]
+	if root.Status != "completed" {
+		t.Fatalf("root status = %s, want completed", root.Status)
+	}
+	if len(root.Children) != 2 {
+		t.Fatalf("expected 2 children, got %d", len(root.Children))
+	}
+	if root.Children[0].Name != "step 1" || root.Children[1].Name != "step 2" {
+		t.Fatalf("children = [%s, %s], want [step 1, step 2]", root.Children[0].Name, root.Children[1].Name)
+	}
+}


### PR DESCRIPTION
StartTrace resolved the parent with getParentTrace(), which returns nil while the root trace is the only open one. So the first level of nesting was silently dropped, and the orphaned EndTrace then popped the path and closed the root trace with the child's end time — later siblings ended up corrupted too.

The Record* methods already attach to getCurrentTrace(); StartTrace now does the same, and the unused getParentTrace() is gone.

This bites anything that nests traces, including the shipped tracing example, and with profiling enabled every user trace is nested under the root "Request Handler" trace, so nothing user-started showed up at all.

Added tests for nested traces and siblings; the first fails with "expected 1 root trace, got 2" on the old code.