### PR TITLE
Fix bogus memory metrics when GC runs during a request

### DIFF
--- a/internal/profiling/profiler.go
+++ b/internal/profiling/profiler.go
@@ -54,6 +54,10 @@ type Metrics struct {
 	CPUProfile       []byte                   `json:"-"` // Raw CPU profile data
 	HeapProfile      []byte                   `json:"-"` // Raw heap profile data
 
+	// Baseline of runtime.MemStats.TotalAlloc at StartProfiling, used to
+	// compute MemoryTotalAlloc as a delta.
+	totalAllocStart uint64
+
 	mu sync.Mutex
 }
 
@@ -181,6 +185,7 @@ func (p *Profiler) StartProfiling(ctx context.Context, requestID string) context
 		var m runtime.MemStats
 		runtime.ReadMemStats(&m)
 		metrics.MemoryAlloc = m.Alloc
+		metrics.totalAllocStart = m.TotalAlloc
 		metrics.NumGC = m.NumGC
 		metrics.GCPauseTotal = time.Duration(m.PauseTotalNs)
 	}
@@ -240,7 +245,9 @@ func (p *Profiler) EndProfiling(ctx context.Context) *Metrics {
 	if p.hasProfile(ProfileMemory) {
 		var m runtime.MemStats
 		runtime.ReadMemStats(&m)
-		metrics.MemoryTotalAlloc = m.Alloc - metrics.MemoryAlloc
+		// TotalAlloc is monotonic, unlike Alloc, which shrinks after GC and
+		// would underflow here.
+		metrics.MemoryTotalAlloc = m.TotalAlloc - metrics.totalAllocStart
 		metrics.MemoryAlloc = m.Alloc
 
 		// Calculate GC impact

--- a/internal/profiling/profiler_test.go
+++ b/internal/profiling/profiler_test.go
@@ -3,6 +3,7 @@ package profiling
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -43,5 +44,35 @@ func TestConcurrentCPUProfiling(t *testing.T) {
 	// Verify that no CPU profiling is still active
 	if profiler.activeCPUProfile != nil {
 		t.Errorf("CPU profiling should not be active after all requests completed")
+	}
+}
+
+// ballastSink keeps the test allocation visible to the compiler.
+var ballastSink []byte
+
+func TestMemoryTotalAllocSurvivesGC(t *testing.T) {
+	profiler := NewProfiler(10)
+	profiler.SetProfileType(ProfileMemory)
+	profiler.SetThreshold(0)
+
+	// Allocate before profiling starts so the baseline heap is high, then
+	// free it and force a GC: live heap at EndProfiling drops below the
+	// baseline, which used to underflow the uint64 delta.
+	ballastSink = make([]byte, 64<<20)
+	ctx := profiler.StartProfiling(context.Background(), "req-mem")
+	ballastSink = nil
+	runtime.GC()
+
+	metrics := profiler.EndProfiling(ctx)
+	if metrics == nil {
+		t.Fatal("expected metrics, got nil")
+	}
+	if metrics.MemoryTotalAlloc > 1<<40 {
+		t.Fatalf("MemoryTotalAlloc = %d, uint64 underflow", metrics.MemoryTotalAlloc)
+	}
+	for _, b := range metrics.Bottlenecks {
+		if b.Type == "memory" {
+			t.Fatalf("unexpected memory bottleneck: %+v", b)
+		}
 	}
 }


### PR DESCRIPTION
MemoryTotalAlloc was computed as the difference of two MemStats.Alloc readings. Alloc is live heap, so when a GC cycle runs during the request the end reading can be lower than the start and the uint64 subtraction wraps to ~1.8e19. The dashboard then shows an absurd allocation number and analyzeBottlenecks flags a false "High memory allocation" bottleneck on every such request.

Switched the delta to MemStats.TotalAlloc, which is monotonic, with the baseline captured at StartProfiling. MemoryAlloc still reports live heap at the end of the request.

The new test allocates a 64MB ballast before profiling starts, frees it and forces a GC, and fails on the old code with the wrapped value.