### PR TITLE
Fix data race on responseWriter after the handler returns

### DIFF
--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -78,6 +78,25 @@ func (w *responseWriter) Write(b []byte) (int, error) {
 	return w.ResponseWriter.Write(b)
 }
 
+// status returns the captured status code. It takes the lock so it stays
+// safe even if a handler goroutine is still writing.
+func (w *responseWriter) status() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.statusCode
+}
+
+// body returns a snapshot of the captured response body, or "" when body
+// logging is off.
+func (w *responseWriter) body() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.buffer == nil {
+		return ""
+	}
+	return w.buffer.String()
+}
+
 // Flush implements http.Flusher, forwarding to the underlying writer if it supports it.
 func (w *responseWriter) Flush() {
 	if f, ok := w.ResponseWriter.(http.Flusher); ok {
@@ -161,7 +180,7 @@ func WrapWithLimits(handler http.Handler, store store.Store, logRequestBody, log
 		start := time.Now()
 		handler.ServeHTTP(resWriter, r)
 		reqLog.Duration = time.Since(start).Milliseconds()
-		reqLog.StatusCode = resWriter.statusCode
+		reqLog.StatusCode = resWriter.status()
 
 		// Extract user-provided middleware-stack information from context
 		if v := r.Context().Value(MiddlewareStackKey{}); v != nil {
@@ -182,8 +201,8 @@ func WrapWithLimits(handler http.Handler, store store.Store, logRequestBody, log
 			}
 		}
 
-		if logResponseBody && resWriter.buffer != nil {
-			reqLog.ResponseBody = resWriter.buffer.String()
+		if logResponseBody {
+			reqLog.ResponseBody = resWriter.body()
 		}
 
 		if err := store.Add(reqLog); err != nil {

--- a/internal/middleware/middleware_test.go
+++ b/internal/middleware/middleware_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/doganarif/govisual/internal/model"
@@ -93,4 +94,26 @@ func TestWrapMiddleware(t *testing.T) {
 	if log.Duration < 0 {
 		t.Errorf("expected Duration > 0, got %d", log.Duration)
 	}
+}
+
+func TestStatusReadRacesWithLateWrites(t *testing.T) {
+	store := &mockStore{}
+	var wg sync.WaitGroup
+
+	// A handler that leaks a goroutine still writing after it returns; the
+	// middleware's post-handler reads must not race with it.
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 100; i++ {
+				w.Write([]byte("late"))
+			}
+		}()
+	})
+
+	wrapped := Wrap(handler, store, false, true, &mockPathMatcher{})
+	rec := httptest.NewRecorder()
+	wrapped.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	wg.Wait()
 }

--- a/internal/middleware/profiling.go
+++ b/internal/middleware/profiling.go
@@ -80,7 +80,7 @@ func WrapWithProfilingAndLimits(handler http.Handler, store store.Store, logRequ
 			}
 		}
 
-		reqLog.StatusCode = resWriter.statusCode
+		reqLog.StatusCode = resWriter.status()
 
 		tracer.EndTrace(nil)
 		tracer.Complete()
@@ -111,8 +111,8 @@ func WrapWithProfilingAndLimits(handler http.Handler, store store.Store, logRequ
 			}
 		}
 
-		if logResponseBody && resWriter.buffer != nil {
-			reqLog.ResponseBody = resWriter.buffer.String()
+		if logResponseBody {
+			reqLog.ResponseBody = resWriter.body()
 		}
 
 		_ = store.Add(reqLog)


### PR DESCRIPTION
responseWriter guards statusCode and the body buffer with a mutex in Write/WriteHeader, but the middleware read both fields without it after ServeHTTP returned. A handler that leaks a goroutine which keeps writing (fire-and-forget streaming and the like) races with those reads — the app is arguably misbehaving at that point, but the race shows up in *our* frames and fails anyone running govisual under go test -race.

Reads now go through locked status()/body() accessors in both the plain and profiling middleware. Added a regression test that leaks a late-writing goroutine; it trips the race detector on the old code and is clean now.