### PR TITLE
Document dashboard security gates, profiling and shutdown options

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,21 @@ handler := govisual.Wrap(
     govisual.WithDashboardPath("/__dashboard"), // Custom dashboard path
     govisual.WithRequestBodyLogging(true),      // Log request bodies
     govisual.WithResponseBodyLogging(true),     // Log response bodies
+    govisual.WithMaxBodyBytes(1 << 20),         // Cap captured body size (default 1 MiB)
     govisual.WithIgnorePaths("/health"),        // Paths to ignore
+
+    // Dashboard access (all off by default)
+    govisual.WithLocalhostOnly(),               // Only loopback addresses may open the dashboard
+    govisual.WithBasicAuth("admin", "secret"),  // Protect the dashboard with Basic Auth
+    govisual.WithReplayEnabled(true),           // Allow replaying captured requests
+    govisual.WithSystemInfo("GOPATH", "HOME"),  // Expose runtime info + allowlisted env vars
+
+    // Profiling
+    govisual.WithProfiling(true),               // Per-request CPU/memory profiling
+    govisual.WithProfileThreshold(50*time.Millisecond), // Only profile slow requests
+
+    govisual.WithShutdownContext(ctx),          // Release storage/telemetry when ctx is cancelled
+
     govisual.WithOpenTelemetry(true),           // Enable OpenTelemetry
     govisual.WithServiceName("my-service"),     // Service name for OTel
     govisual.WithServiceVersion("1.0.0"),       // Service version
@@ -83,6 +97,15 @@ handler := govisual.Wrap(
     ),
 )
 ```
+
+## Dashboard Security
+
+The dashboard is meant for local development, so the risky endpoints are off unless you opt in:
+
+- **Request replay** (`WithReplayEnabled`) is disabled by default — the endpoint makes the server issue outbound HTTP requests, so only enable it together with `WithLocalhostOnly()` or auth.
+- **System info** (`WithSystemInfo`) is disabled by default. Environment variables are only exposed if you pass their names explicitly: `WithSystemInfo("GOPATH", "HOME")`.
+- `WithBasicAuth(user, pass)` or `WithDashboardAuth(func(*http.Request) bool)` gate every dashboard request.
+- `WithLocalhostOnly()` rejects dashboard requests from non-loopback addresses.
 
 ## Storage Backends
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -121,6 +121,196 @@ Sets path patterns to ignore from request logging.
 govisual.WithIgnorePaths("/health", "/metrics", "/static/*")
 ```
 
+#### WithMaxBodyBytes
+
+```go
+func WithMaxBodyBytes(n int) Option
+```
+
+Caps the captured request and response body size. `0` uses the package default (1 MiB), a positive value sets an explicit cap in bytes, and a negative value disables the cap.
+
+**Parameters:**
+
+- `n int`: Body capture cap in bytes
+
+**Example:**
+
+```go
+govisual.WithMaxBodyBytes(64 << 10)
+```
+
+### Dashboard Security Options
+
+#### WithLocalhostOnly
+
+```go
+func WithLocalhostOnly() Option
+```
+
+Restricts the dashboard to requests originating from a loopback address.
+
+**Example:**
+
+```go
+govisual.WithLocalhostOnly()
+```
+
+#### WithBasicAuth
+
+```go
+func WithBasicAuth(username, password string) Option
+```
+
+Protects the dashboard with HTTP Basic Auth using a constant-time comparison.
+
+**Parameters:**
+
+- `username string`: Expected username
+- `password string`: Expected password
+
+**Example:**
+
+```go
+govisual.WithBasicAuth("admin", "secret")
+```
+
+#### WithDashboardAuth
+
+```go
+func WithDashboardAuth(fn DashboardAuth) Option
+```
+
+Installs a custom authentication function. It runs on every dashboard request and must return true to allow access.
+
+**Parameters:**
+
+- `fn DashboardAuth`: `func(*http.Request) bool`
+
+**Example:**
+
+```go
+govisual.WithDashboardAuth(func(r *http.Request) bool {
+    return r.Header.Get("X-Debug-Token") == "s3cret"
+})
+```
+
+#### WithReplayEnabled
+
+```go
+func WithReplayEnabled(enabled bool) Option
+```
+
+Enables the dashboard's replay endpoint. Disabled by default: the endpoint makes the server perform outbound HTTP requests (an SSRF primitive), so only enable it behind authentication and/or localhost-only access.
+
+**Parameters:**
+
+- `enabled bool`: Whether replay is allowed
+
+**Example:**
+
+```go
+govisual.WithReplayEnabled(true)
+```
+
+#### WithSystemInfo
+
+```go
+func WithSystemInfo(envAllowlist ...string) Option
+```
+
+Enables the dashboard's system-info endpoint. Environment variables are only exposed when their names are passed here; with no names, only memory and runtime info is shown.
+
+**Parameters:**
+
+- `envAllowlist ...string`: Environment variable names to expose
+
+**Example:**
+
+```go
+govisual.WithSystemInfo("GOPATH", "GOOS")
+```
+
+### Profiling Options
+
+#### WithProfiling
+
+```go
+func WithProfiling(enabled bool) Option
+```
+
+Enables per-request performance profiling (CPU, memory, goroutines).
+
+**Example:**
+
+```go
+govisual.WithProfiling(true)
+```
+
+#### WithProfileType
+
+```go
+func WithProfileType(profileType profiling.ProfileType) Option
+```
+
+Sets which profile types to collect. Defaults to all.
+
+**Example:**
+
+```go
+govisual.WithProfileType(profiling.ProfileCPU)
+```
+
+#### WithProfileThreshold
+
+```go
+func WithProfileThreshold(threshold time.Duration) Option
+```
+
+Only keeps profiles for requests slower than the threshold. Defaults to 10ms.
+
+**Example:**
+
+```go
+govisual.WithProfileThreshold(50 * time.Millisecond)
+```
+
+#### WithMaxProfileMetrics
+
+```go
+func WithMaxProfileMetrics(max int) Option
+```
+
+Sets the maximum number of profile records to keep. Defaults to 1000.
+
+**Example:**
+
+```go
+govisual.WithMaxProfileMetrics(500)
+```
+
+### Lifecycle Options
+
+#### WithShutdownContext
+
+```go
+func WithShutdownContext(ctx context.Context) Option
+```
+
+Wires govisual's internal cleanup (storage backends, OpenTelemetry shutdown) to a caller-provided context: when the context is cancelled, govisual releases its resources. GoVisual does not install signal handlers — shutdown stays under the host application's control.
+
+**Parameters:**
+
+- `ctx context.Context`: Context whose cancellation triggers cleanup
+
+**Example:**
+
+```go
+ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+defer stop()
+
+handler := govisual.Wrap(mux, govisual.WithShutdownContext(ctx))
+```
+
 ### Storage Options
 
 #### WithMemoryStorage

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,6 +26,27 @@ handler := govisual.Wrap(
 | `WithRequestBodyLogging(bool)`  | Enable logging of request bodies      | false      | `govisual.WithRequestBodyLogging(true)`           |
 | `WithResponseBodyLogging(bool)` | Enable logging of response bodies     | false      | `govisual.WithResponseBodyLogging(true)`          |
 | `WithIgnorePaths(...string)`    | Paths to exclude from logging         | []         | `govisual.WithIgnorePaths("/health", "/metrics")` |
+| `WithMaxBodyBytes(int)`         | Cap on captured body size in bytes (0 = 1 MiB default, negative = unbounded) | 1 MiB | `govisual.WithMaxBodyBytes(64 << 10)` |
+| `WithShutdownContext(ctx)`      | Release storage and telemetry resources when the context is cancelled | none | `govisual.WithShutdownContext(ctx)` |
+
+### Dashboard Security
+
+| Option                              | Description                                                        | Default  | Example                                        |
+| ----------------------------------- | ------------------------------------------------------------------ | -------- | ---------------------------------------------- |
+| `WithLocalhostOnly()`               | Only allow dashboard requests from loopback addresses              | off      | `govisual.WithLocalhostOnly()`                 |
+| `WithBasicAuth(user, pass)`         | Protect the dashboard with HTTP Basic Auth (constant-time compare) | off      | `govisual.WithBasicAuth("admin", "secret")`    |
+| `WithDashboardAuth(fn)`             | Custom auth check run on every dashboard request                   | off      | `govisual.WithDashboardAuth(myCheck)`          |
+| `WithReplayEnabled(bool)`           | Enable the request replay endpoint (SSRF primitive — keep it gated) | disabled | `govisual.WithReplayEnabled(true)`             |
+| `WithSystemInfo(...string)`         | Enable the system-info endpoint; env vars shown only if allowlisted | disabled | `govisual.WithSystemInfo("GOPATH")`            |
+
+### Profiling Options
+
+| Option                            | Description                                | Default | Example                                              |
+| --------------------------------- | ------------------------------------------ | ------- | ---------------------------------------------------- |
+| `WithProfiling(bool)`             | Enable per-request CPU/memory profiling    | false   | `govisual.WithProfiling(true)`                       |
+| `WithProfileType(type)`           | Which profiles to collect                  | all     | `govisual.WithProfileType(profiling.ProfileCPU)`     |
+| `WithProfileThreshold(duration)`  | Only keep profiles for requests slower than this | 10ms | `govisual.WithProfileThreshold(50 * time.Millisecond)` |
+| `WithMaxProfileMetrics(int)`      | Maximum number of profile records to keep  | 1000    | `govisual.WithMaxProfileMetrics(500)`                |
 
 ### Storage Options
 
@@ -64,6 +85,18 @@ handler := govisual.Wrap(
 handler := govisual.Wrap(
     mux,
     govisual.WithDashboardPath("/__debug"),
+)
+```
+
+### Secured Dashboard
+
+```go
+handler := govisual.Wrap(
+    mux,
+    govisual.WithLocalhostOnly(),
+    govisual.WithBasicAuth("admin", "secret"),
+    govisual.WithReplayEnabled(true),
+    govisual.WithSystemInfo("GOPATH", "GOOS"),
 )
 ```
 


### PR DESCRIPTION
The docs stopped at the OTel options: nothing mentioned profiling (added with the React dashboard) or the security gates and lifecycle changes from #37. Anyone reading the README wouldn't know replay and system-info are now opt-in, or that WithShutdownContext replaced the old signal handler.

- README: new options in the configuration block plus a short Dashboard Security section explaining the defaults
- configuration.md: tables for dashboard security and profiling, WithMaxBodyBytes/WithShutdownContext rows, a secured-dashboard example
- api-reference.md: full entries for the eleven undocumented options

Docs only, no code changes.