### PR TITLE
Fix Redis result ordering and expired-key index divergence

### DIFF
--- a/internal/store/redis.go
+++ b/internal/store/redis.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"sort"
 	"sync/atomic"
 	"time"
 
@@ -174,10 +173,12 @@ func (s *RedisStore) getLogs(ctx context.Context, ids []string) []*model.Request
 		return nil
 	}
 
+	// Keep results aligned with ids so the ZRevRange order survives; a map
+	// here would shuffle entries that share a timestamp.
 	pipe := s.client.Pipeline()
-	cmds := make(map[string]*redis.StringCmd, len(ids))
-	for _, id := range ids {
-		cmds[id] = pipe.Get(ctx, s.keyPrefix+id)
+	cmds := make([]*redis.StringCmd, len(ids))
+	for i, id := range ids {
+		cmds[i] = pipe.Get(ctx, s.keyPrefix+id)
 	}
 	if _, err := pipe.Exec(ctx); err != nil && err != redis.Nil {
 		log.Printf("govisual: failed to execute Redis pipeline: %v", err)
@@ -185,25 +186,32 @@ func (s *RedisStore) getLogs(ctx context.Context, ids []string) []*model.Request
 	}
 
 	logs := make([]*model.RequestLog, 0, len(ids))
-	for id, cmd := range cmds {
+	var expired []interface{}
+	for i, cmd := range cmds {
 		data, err := cmd.Bytes()
 		if err != nil {
-			if err != redis.Nil {
-				log.Printf("govisual: failed to get Redis log %s: %v", id, err)
+			if err == redis.Nil {
+				// The key expired but its ID is still indexed; prune it so
+				// the sorted set doesn't diverge from the key space.
+				expired = append(expired, ids[i])
+			} else {
+				log.Printf("govisual: failed to get Redis log %s: %v", ids[i], err)
 			}
 			continue
 		}
 		var reqLog model.RequestLog
 		if err := json.Unmarshal(data, &reqLog); err != nil {
-			log.Printf("govisual: failed to unmarshal Redis log %s: %v", id, err)
+			log.Printf("govisual: failed to unmarshal Redis log %s: %v", ids[i], err)
 			continue
 		}
 		logs = append(logs, &reqLog)
 	}
 
-	sort.Slice(logs, func(i, j int) bool {
-		return logs[i].Timestamp.After(logs[j].Timestamp)
-	})
+	if len(expired) > 0 {
+		if err := s.client.ZRem(ctx, s.keyPrefix+"logs", expired...).Err(); err != nil {
+			log.Printf("govisual: failed to prune expired Redis log IDs: %v", err)
+		}
+	}
 	return logs
 }
 

--- a/internal/store/redis_test.go
+++ b/internal/store/redis_test.go
@@ -1,8 +1,12 @@
 package store
 
 import (
+	"context"
 	"os"
 	"testing"
+	"time"
+
+	"github.com/doganarif/govisual/internal/model"
 )
 
 func TestRedisStore(t *testing.T) {
@@ -17,4 +21,82 @@ func TestRedisStore(t *testing.T) {
 	}
 
 	runStoreTests(t, store)
+}
+
+func TestRedisStoreOrderStableForEqualTimestamps(t *testing.T) {
+	connStr := os.Getenv("REDIS_CONN")
+	if connStr == "" {
+		t.Skip("REDIS_CONN not set; skipping Redis test")
+	}
+
+	store, err := NewRedisStore(connStr, 10, 3600)
+	if err != nil {
+		t.Fatalf("failed to create Redis store: %v", err)
+	}
+	defer store.Close()
+	defer store.Clear()
+
+	// Same timestamp for every entry: order must come from the sorted set
+	// (reverse-lexicographic on ID for equal scores), not map iteration.
+	ts := time.Now()
+	for _, id := range []string{"a", "b", "c", "d"} {
+		store.Add(&model.RequestLog{ID: id, Timestamp: ts, Method: "GET", Path: "/x"})
+	}
+
+	want := []string{"d", "c", "b", "a"}
+	for run := 0; run < 5; run++ {
+		all := store.GetAll()
+		if len(all) != len(want) {
+			t.Fatalf("expected %d logs, got %d", len(want), len(all))
+		}
+		for i, w := range want {
+			if all[i].ID != w {
+				t.Fatalf("run %d: order = %v, want %v", run, ids(all), want)
+			}
+		}
+	}
+}
+
+func TestRedisStorePrunesExpiredIDs(t *testing.T) {
+	connStr := os.Getenv("REDIS_CONN")
+	if connStr == "" {
+		t.Skip("REDIS_CONN not set; skipping Redis test")
+	}
+
+	store, err := NewRedisStore(connStr, 10, 3600)
+	if err != nil {
+		t.Fatalf("failed to create Redis store: %v", err)
+	}
+	defer store.Close()
+	defer store.Clear()
+
+	store.Add(&model.RequestLog{ID: "keep", Timestamp: time.Now(), Method: "GET", Path: "/x"})
+	store.Add(&model.RequestLog{ID: "gone", Timestamp: time.Now(), Method: "GET", Path: "/x"})
+
+	// Simulate TTL expiry: the key vanishes but the sorted set still has the ID.
+	ctx := context.Background()
+	if err := store.client.Del(ctx, store.keyPrefix+"gone").Err(); err != nil {
+		t.Fatalf("failed to delete key: %v", err)
+	}
+
+	all := store.GetAll()
+	if len(all) != 1 || all[0].ID != "keep" {
+		t.Fatalf("expected only 'keep', got %v", ids(all))
+	}
+
+	card, err := store.client.ZCard(ctx, store.keyPrefix+"logs").Result()
+	if err != nil {
+		t.Fatalf("zcard: %v", err)
+	}
+	if card != 1 {
+		t.Fatalf("expected expired ID pruned from sorted set, ZCARD = %d", card)
+	}
+}
+
+func ids(logs []*model.RequestLog) []string {
+	out := make([]string, len(logs))
+	for i, l := range logs {
+		out[i] = l.ID
+	}
+	return out
 }


### PR DESCRIPTION
getLogs collected pipeline results in a map, which throws away the ZRevRange ordering. The trailing sort by timestamp papered over it except for entries sharing a timestamp — those came back in random order on every call. On top of that, keys that hit their TTL were silently skipped but their IDs stayed in the sorted set forever, so the index slowly filled with dead references (capacity cleanup only trims by count, it never noticed).

Results now stay aligned with the ZRevRange id list, the redundant re-sort is gone, and expired IDs get pruned from the sorted set when a read discovers them.

Both new tests run against real Redis (skipped without REDIS_CONN, exercised in CI): the ordering test fails on the old code, and the pruning test verifies ZCARD shrinks after an expired key is encountered.