### PR TITLE
Fix capacity cleanup overshooting under concurrent writes

### DIFF
--- a/internal/store/mongodb.go
+++ b/internal/store/mongodb.go
@@ -82,18 +82,11 @@ func (m *MongoDBStore) cleanup() {
 	ctx, cancel := m.opCtx()
 	defer cancel()
 
-	count, err := m.collection.CountDocuments(ctx, bson.M{})
-	if err != nil {
-		log.Printf("govisual: failed to count MongoDB logs: %v", err)
-		return
-	}
-	if count <= int64(m.capacity) {
-		return
-	}
-
+	// Select everything beyond the newest m.capacity documents by rank; a
+	// separate count would go stale under concurrent inserts.
 	findOptions := options.Find().
-		SetSort(bson.D{{Key: "timestamp", Value: 1}}).
-		SetLimit(count - int64(m.capacity)).
+		SetSort(bson.D{{Key: "timestamp", Value: -1}}).
+		SetSkip(int64(m.capacity)).
 		SetProjection(bson.M{"_id": 1})
 
 	cursor, err := m.collection.Find(ctx, bson.M{}, findOptions)

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -158,26 +158,18 @@ func prepareJSON(v interface{}) string {
 
 // cleanup removes old logs to maintain the capacity limit
 func (s *PostgresStore) cleanup() {
-	countQuery := fmt.Sprintf("SELECT COUNT(*) FROM %s", s.tableName)
-	var count int
-	if err := s.db.QueryRow(countQuery).Scan(&count); err != nil {
-		log.Printf("govisual: failed to count logs: %v", err)
-		return
-	}
-	if count <= s.capacity {
-		return
-	}
-
+	// One statement that keeps the newest rows; a separate COUNT would go
+	// stale under concurrent inserts and leave the table above capacity.
 	deleteQuery := fmt.Sprintf(`
 		DELETE FROM %s
-		WHERE id IN (
+		WHERE id NOT IN (
 			SELECT id FROM %s
-			ORDER BY timestamp ASC
+			ORDER BY timestamp DESC
 			LIMIT $1
 		)
 	`, s.tableName, s.tableName)
 
-	if _, err := s.db.Exec(deleteQuery, count-s.capacity); err != nil {
+	if _, err := s.db.Exec(deleteQuery, s.capacity); err != nil {
 		log.Printf("govisual: failed to clean up old logs: %v", err)
 	}
 }

--- a/internal/store/redis.go
+++ b/internal/store/redis.go
@@ -90,16 +90,9 @@ func (s *RedisStore) cleanup() {
 	ctx, cancel := s.opCtx()
 	defer cancel()
 
-	count, err := s.client.ZCard(ctx, s.keyPrefix+"logs").Result()
-	if err != nil {
-		log.Printf("govisual: failed to count Redis logs: %v", err)
-		return
-	}
-	if count <= int64(s.capacity) {
-		return
-	}
-
-	oldestIDs, err := s.client.ZRange(ctx, s.keyPrefix+"logs", 0, count-int64(s.capacity)-1).Result()
+	// Everything except the newest s.capacity members, by rank; a separate
+	// ZCARD would go stale under concurrent inserts.
+	oldestIDs, err := s.client.ZRange(ctx, s.keyPrefix+"logs", 0, int64(-(s.capacity + 1))).Result()
 	if err != nil {
 		log.Printf("govisual: failed to get oldest Redis log IDs: %v", err)
 		return

--- a/internal/store/redis_test.go
+++ b/internal/store/redis_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -99,4 +100,40 @@ func ids(logs []*model.RequestLog) []string {
 		out[i] = l.ID
 	}
 	return out
+}
+
+func TestRedisStoreCleanupKeepsNewest(t *testing.T) {
+	connStr := os.Getenv("REDIS_CONN")
+	if connStr == "" {
+		t.Skip("REDIS_CONN not set; skipping Redis test")
+	}
+
+	store, err := NewRedisStore(connStr, 10, 3600)
+	if err != nil {
+		t.Fatalf("failed to create Redis store: %v", err)
+	}
+	defer store.Close()
+	defer store.Clear()
+
+	base := time.Now()
+	for i := 0; i < 25; i++ {
+		store.Add(&model.RequestLog{
+			ID:        fmt.Sprintf("req-%02d", i),
+			Timestamp: base.Add(time.Duration(i) * time.Second),
+			Method:    "GET",
+			Path:      "/x",
+		})
+	}
+
+	store.cleanup()
+
+	all := store.GetAll()
+	if len(all) != 10 {
+		t.Fatalf("expected capacity 10 after cleanup, got %d", len(all))
+	}
+	for _, l := range all {
+		if l.ID < "req-15" {
+			t.Fatalf("old entry %s survived cleanup", l.ID)
+		}
+	}
 }

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -177,26 +177,18 @@ func (s *SQLiteStore) Add(reqLog *model.RequestLog) error {
 }
 
 func (s *SQLiteStore) cleanup() {
-	countQuery := fmt.Sprintf("SELECT COUNT(*) FROM %s", s.tableName)
-	var count int
-	if err := s.db.QueryRow(countQuery).Scan(&count); err != nil {
-		log.Printf("govisual: failed to count logs: %v", err)
-		return
-	}
-	if count <= s.capacity {
-		return
-	}
-
+	// One statement that keeps the newest rows; a separate COUNT would go
+	// stale under concurrent inserts and leave the table above capacity.
 	deleteQuery := fmt.Sprintf(`
 		DELETE FROM %s
-		WHERE id IN (
+		WHERE id NOT IN (
 			SELECT id FROM %s
-			ORDER BY created_at ASC, timestamp ASC
+			ORDER BY created_at DESC, timestamp DESC
 			LIMIT ?
 		)
 	`, s.tableName, s.tableName)
 
-	if _, err := s.db.Exec(deleteQuery, count-s.capacity); err != nil {
+	if _, err := s.db.Exec(deleteQuery, s.capacity); err != nil {
 		log.Printf("govisual: failed to clean up old logs: %v", err)
 	}
 }

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -1,9 +1,13 @@
 package store
 
 import (
+	"fmt"
+	"time"
+
 	"database/sql"
 	"testing"
 
+	"github.com/doganarif/govisual/internal/model"
 	_ "github.com/mattn/go-sqlite3"
 )
 
@@ -20,4 +24,39 @@ func TestSQLiteStore(t *testing.T) {
 	}
 
 	runStoreTests(t, store)
+}
+
+func TestSQLiteStoreCleanupKeepsNewest(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open sqlite3: %v", err)
+	}
+	defer db.Close()
+
+	store, err := NewSQLiteStoreWithDB(db, "logs", 10)
+	if err != nil {
+		t.Fatalf("failed to create SQLite store: %v", err)
+	}
+
+	base := time.Now()
+	for i := 0; i < 25; i++ {
+		store.Add(&model.RequestLog{
+			ID:        fmt.Sprintf("req-%02d", i),
+			Timestamp: base.Add(time.Duration(i) * time.Second),
+			Method:    "GET",
+			Path:      "/x",
+		})
+	}
+
+	store.cleanup()
+
+	all := store.GetAll()
+	if len(all) != 10 {
+		t.Fatalf("expected capacity 10 after cleanup, got %d", len(all))
+	}
+	for _, l := range all {
+		if l.ID < "req-15" {
+			t.Fatalf("old entry %s survived cleanup", l.ID)
+		}
+	}
 }


### PR DESCRIPTION
Every backend's cleanup did a count first and then deleted (count - capacity) oldest entries. Between the two steps concurrent inserts land, so the delete removes too few rows and the store settles above its configured capacity. The overshoot compounds because cleanup only runs every 32nd insert.

The trim is now expressed as "keep the newest capacity entries" instead of count arithmetic:

- SQLite/Postgres: single DELETE ... WHERE id NOT IN (SELECT ... ORDER BY ... DESC LIMIT capacity)
- MongoDB: find sorted newest-first with skip(capacity), delete the tail
- Redis: ZRANGE 0 -(capacity+1) picks everything below the newest capacity by rank

Races during the trim can only add entries that belong to the keep-set anyway, so the delete set stays correct by construction. A perfectly-timed concurrency repro isn't testable deterministically; the new SQLite and Redis tests pin the keep-newest semantics (25 in, capacity 10, the 10 newest survive).