### PR TITLE
v2: dashboard is localhost-only by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ handler := govisual.Wrap(
     govisual.WithIgnorePaths("/health"),        // Paths to ignore
 
     // Dashboard access (all off by default)
-    govisual.WithLocalhostOnly(),               // Only loopback addresses may open the dashboard
+    govisual.WithAllowRemote(),                 // Dashboard is loopback-only by default; opt out here
     govisual.WithBasicAuth("admin", "secret"),  // Protect the dashboard with Basic Auth
     govisual.WithReplayEnabled(true),           // Allow replaying captured requests
     govisual.WithSystemInfo("GOPATH", "HOME"),  // Expose runtime info + allowlisted env vars
@@ -113,12 +113,12 @@ handler := govisual.Wrap(traced) // wrapping the traced mux keeps the dashboard 
 
 ## Dashboard Security
 
-The dashboard is meant for local development, so the risky endpoints are off unless you opt in:
+The dashboard is meant for local development, so everything risky is off unless you opt in:
 
-- **Request replay** (`WithReplayEnabled`) is disabled by default — the endpoint makes the server issue outbound HTTP requests, so only enable it together with `WithLocalhostOnly()` or auth.
+- **The dashboard only answers loopback addresses by default.** `WithAllowRemote()` opens it up — pair that with auth.
+- **Request replay** (`WithReplayEnabled`) is disabled by default — the endpoint makes the server issue outbound HTTP requests.
 - **System info** (`WithSystemInfo`) is disabled by default. Environment variables are only exposed if you pass their names explicitly: `WithSystemInfo("GOPATH", "HOME")`.
 - `WithBasicAuth(user, pass)` or `WithDashboardAuth(func(*http.Request) bool)` gate every dashboard request.
-- `WithLocalhostOnly()` rejects dashboard requests from non-loopback addresses.
 
 ## Storage Backends
 

--- a/options.go
+++ b/options.go
@@ -53,9 +53,9 @@ type Config struct {
 	// If nil, the dashboard is fully open — only safe for local dev.
 	DashboardAuth DashboardAuth
 
-	// LocalhostOnly, when true, rejects dashboard requests whose remote address
-	// is not a loopback IP. This is the safest default for "I'm just debugging
-	// locally" — even with the rest of the server bound to 0.0.0.0.
+	// LocalhostOnly rejects dashboard requests whose remote address is not a
+	// loopback IP. On by default — even with the rest of the server bound to
+	// 0.0.0.0, the dashboard stays local unless WithAllowRemote is used.
 	LocalhostOnly bool
 
 	// EnableReplay enables the POST /__viz/api/replay endpoint, which lets the
@@ -218,11 +218,20 @@ func WithBasicAuth(username, password string) Option {
 }
 
 // WithLocalhostOnly restricts the dashboard to requests originating from a
-// loopback address. Combine with WithDashboardAuth/WithBasicAuth for defense
-// in depth.
+// loopback address. This is the default; the option exists so the intent can
+// be stated explicitly.
 func WithLocalhostOnly() Option {
 	return func(c *Config) {
 		c.LocalhostOnly = true
+	}
+}
+
+// WithAllowRemote lets non-loopback addresses reach the dashboard. Pair it
+// with WithBasicAuth or WithDashboardAuth — an open dashboard exposes every
+// captured request and response body to whoever can reach the port.
+func WithAllowRemote() Option {
+	return func(c *Config) {
+		c.LocalhostOnly = false
 	}
 }
 
@@ -276,6 +285,7 @@ func defaultConfig() *Config {
 		ProfileType:         profiling.ProfileAll,
 		ProfileThreshold:    10 * time.Millisecond,
 		MaxProfileMetrics:   1000,
+		LocalhostOnly:       true,
 		EnableReplay:        false,
 		ExposeSystemInfo:    false,
 	}

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -1,0 +1,35 @@
+package govisual
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func dashboardStatus(t *testing.T, remoteAddr string, opts ...Option) int {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {})
+	h := Wrap(mux, opts...)
+
+	req := httptest.NewRequest(http.MethodGet, "/__viz/api/requests", nil)
+	req.RemoteAddr = remoteAddr
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec.Code
+}
+
+func TestDashboardLocalhostOnlyByDefault(t *testing.T) {
+	if got := dashboardStatus(t, "127.0.0.1:5555"); got != http.StatusOK {
+		t.Fatalf("loopback request: got %d, want 200", got)
+	}
+	if got := dashboardStatus(t, "203.0.113.7:5555"); got != http.StatusForbidden {
+		t.Fatalf("remote request: got %d, want 403", got)
+	}
+}
+
+func TestDashboardAllowRemote(t *testing.T) {
+	if got := dashboardStatus(t, "203.0.113.7:5555", WithAllowRemote()); got != http.StatusOK {
+		t.Fatalf("remote request with WithAllowRemote: got %d, want 200", got)
+	}
+}


### PR DESCRIPTION
The dashboard now rejects non-loopback requests out of the box; WithAllowRemote() opens it up for anyone who genuinely wants a remotely reachable debugger (pair with WithBasicAuth). WithLocalhostOnly stays as an explicit no-op-by-default for people who want the intent in code.

Captured request/response bodies are the crown jewels of this tool — with the server bound to 0.0.0.0 on a LAN, the old default quietly served them to the whole network. v2 is the window to flip this.

Tests pin the default (loopback 200, remote 403) and the opt-out.