### PR TITLE
Push live updates to the dashboard instead of polling

### DIFF
--- a/internal/dashboard/handler.go
+++ b/internal/dashboard/handler.go
@@ -198,7 +198,20 @@ func (h *Handler) handleSSE(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ticker := time.NewTicker(2 * time.Second)
+	// When the store is notifying (the default via Wrap), new entries are
+	// pushed as they arrive; the ticker degrades to a heartbeat and a
+	// safety-net resync.
+	var notify <-chan struct{}
+	if ns, ok := h.store.(*store.NotifyingStore); ok {
+		ch, cancel := ns.Subscribe()
+		defer cancel()
+		notify = ch
+	}
+	tick := 15 * time.Second
+	if notify == nil {
+		tick = 2 * time.Second
+	}
+	ticker := time.NewTicker(tick)
 	defer ticker.Stop()
 
 	// Seed lastSeen from the snapshot we just sent. Without this, the first
@@ -208,48 +221,65 @@ func (h *Handler) handleSSE(w http.ResponseWriter, r *http.Request) {
 	if len(initial) > 0 {
 		lastSeen = initial[0].ID
 	}
+
+	// flushNew announces entries added since lastSeen. heartbeat controls
+	// whether an idle pass emits a keep-alive comment.
+	flushNew := func(heartbeat bool) bool {
+		latest := h.store.GetLatest(50)
+		// Find any entries newer than what we last announced. The store
+		// returns newest-first, so we slice everything before lastSeen.
+		found := lastSeen == ""
+		cutoff := len(latest)
+		for i, l := range latest {
+			if l.ID == lastSeen {
+				cutoff = i
+				found = true
+				break
+			}
+		}
+		if lastSeen != "" && !found {
+			// lastSeen is no longer in the store — the user cleared the
+			// log (or it rolled out of the cap). Resync the client with a
+			// fresh snapshot so it discards the stale entries.
+			if !writeEvent("snapshot", latest) {
+				return false
+			}
+			if len(latest) > 0 {
+				lastSeen = latest[0].ID
+			} else {
+				lastSeen = ""
+			}
+			return true
+		}
+		if cutoff == 0 {
+			if !heartbeat {
+				return true
+			}
+			// Heartbeat keeps proxies from closing idle connections.
+			if _, err := io.WriteString(w, ": ping\n\n"); err != nil {
+				return false
+			}
+			flusher.Flush()
+			return true
+		}
+		fresh := latest[:cutoff]
+		if !writeEvent("append", fresh) {
+			return false
+		}
+		lastSeen = fresh[0].ID
+		return true
+	}
+
 	for {
 		select {
-		case <-ticker.C:
-			latest := h.store.GetLatest(50)
-			// Find any entries newer than what we last announced. The store
-			// returns newest-first, so we slice everything before lastSeen.
-			found := lastSeen == ""
-			cutoff := len(latest)
-			for i, l := range latest {
-				if l.ID == lastSeen {
-					cutoff = i
-					found = true
-					break
-				}
-			}
-			if lastSeen != "" && !found {
-				// lastSeen is no longer in the store — the user cleared the
-				// log (or it rolled out of the cap). Resync the client with a
-				// fresh snapshot so it discards the stale entries.
-				if !writeEvent("snapshot", latest) {
-					return
-				}
-				if len(latest) > 0 {
-					lastSeen = latest[0].ID
-				} else {
-					lastSeen = ""
-				}
-				continue
-			}
-			if cutoff == 0 {
-				// Heartbeat keeps proxies from closing idle connections.
-				if _, err := io.WriteString(w, ": ping\n\n"); err != nil {
-					return
-				}
-				flusher.Flush()
-				continue
-			}
-			fresh := latest[:cutoff]
-			if !writeEvent("append", fresh) {
+		case <-notify:
+			if !flushNew(false) {
 				return
 			}
-			lastSeen = fresh[0].ID
+		case <-ticker.C:
+			if !flushNew(true) {
+				return
+			}
 		case <-r.Context().Done():
 			return
 		}

--- a/internal/dashboard/handler_test.go
+++ b/internal/dashboard/handler_test.go
@@ -1,0 +1,56 @@
+package dashboard
+
+import (
+	"bufio"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/doganarif/govisual/v2/store"
+)
+
+func TestSSEPushesOnAdd(t *testing.T) {
+	ns := store.WithNotify(store.NewMemory(10))
+	srv := httptest.NewServer(NewHandler(ns, nil, HandlerOptions{}))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/events")
+	if err != nil {
+		t.Fatalf("connect SSE: %v", err)
+	}
+	defer resp.Body.Close()
+
+	events := make(chan string, 16)
+	go func() {
+		scanner := bufio.NewScanner(resp.Body)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if strings.HasPrefix(line, "event: ") {
+				events <- strings.TrimPrefix(line, "event: ")
+			}
+		}
+	}()
+
+	select {
+	case ev := <-events:
+		if ev != "snapshot" {
+			t.Fatalf("first event = %q, want snapshot", ev)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no snapshot event")
+	}
+
+	ns.Add(&store.RequestLog{ID: "x1", Timestamp: time.Now(), Method: "GET", Path: "/p"})
+
+	// The push must arrive well under the 15s heartbeat tick.
+	select {
+	case ev := <-events:
+		if ev != "append" {
+			t.Fatalf("second event = %q, want append", ev)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("append was not pushed; SSE still waiting on the ticker")
+	}
+}

--- a/store/notify.go
+++ b/store/notify.go
@@ -1,0 +1,54 @@
+package store
+
+import "sync"
+
+// NotifyingStore wraps a Store so every successful Add signals subscribers.
+// The dashboard uses it to push live updates instead of polling; anything
+// that wants to react to new requests can Subscribe.
+type NotifyingStore struct {
+	Store
+	mu   sync.Mutex
+	subs map[chan struct{}]struct{}
+}
+
+// WithNotify wraps s with change notification.
+func WithNotify(s Store) *NotifyingStore {
+	return &NotifyingStore{
+		Store: s,
+		subs:  make(map[chan struct{}]struct{}),
+	}
+}
+
+func (n *NotifyingStore) Add(l *RequestLog) error {
+	if err := n.Store.Add(l); err != nil {
+		return err
+	}
+	n.mu.Lock()
+	for ch := range n.subs {
+		// Non-blocking: the buffered channel coalesces bursts, a slow
+		// subscriber still sees one signal for the newest write.
+		select {
+		case ch <- struct{}{}:
+		default:
+		}
+	}
+	n.mu.Unlock()
+	return nil
+}
+
+// Subscribe returns a channel that receives a signal after each Add, and a
+// cancel function that must be called when done. Signals carry no payload;
+// read the store for the actual entries.
+func (n *NotifyingStore) Subscribe() (<-chan struct{}, func()) {
+	ch := make(chan struct{}, 1)
+	n.mu.Lock()
+	n.subs[ch] = struct{}{}
+	n.mu.Unlock()
+
+	cancel := func() {
+		n.mu.Lock()
+		delete(n.subs, ch)
+		n.mu.Unlock()
+	}
+	return ch, cancel
+}

--- a/store/notify_test.go
+++ b/store/notify_test.go
@@ -1,0 +1,57 @@
+package store_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/doganarif/govisual/v2/store"
+)
+
+func TestNotifyingStoreSignalsOnAdd(t *testing.T) {
+	ns := store.WithNotify(store.NewMemory(10))
+	ch, cancel := ns.Subscribe()
+	defer cancel()
+
+	ns.Add(&store.RequestLog{ID: "a", Timestamp: time.Now()})
+
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatal("expected a signal after Add")
+	}
+
+	if _, ok := ns.Get("a"); !ok {
+		t.Fatal("expected Add to reach the wrapped store")
+	}
+}
+
+func TestNotifyingStoreCoalescesBursts(t *testing.T) {
+	ns := store.WithNotify(store.NewMemory(10))
+	ch, cancel := ns.Subscribe()
+	defer cancel()
+
+	for i := 0; i < 5; i++ {
+		ns.Add(&store.RequestLog{ID: string(rune('a' + i)), Timestamp: time.Now()})
+	}
+
+	// At least one signal must be pending; draining should not block.
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatal("expected a coalesced signal")
+	}
+}
+
+func TestNotifyingStoreCancelStopsDelivery(t *testing.T) {
+	ns := store.WithNotify(store.NewMemory(10))
+	ch, cancel := ns.Subscribe()
+	cancel()
+
+	ns.Add(&store.RequestLog{ID: "a", Timestamp: time.Now()})
+
+	select {
+	case <-ch:
+		t.Fatal("cancelled subscriber should not receive signals")
+	case <-time.After(50 * time.Millisecond):
+	}
+}

--- a/wrap.go
+++ b/wrap.go
@@ -25,10 +25,12 @@ func Wrap(handler http.Handler, opts ...Option) http.Handler {
 		opt(config)
 	}
 
-	requestStore := config.Store
+	var requestStore store.Store = config.Store
 	if requestStore == nil {
 		requestStore = store.NewMemory(config.MaxRequests)
 	}
+	// Notification lets the dashboard push live updates instead of polling.
+	requestStore = store.WithNotify(requestStore)
 
 	var profiler *profiling.Profiler
 	if config.EnableProfiling {


### PR DESCRIPTION
The SSE stream ticked every two seconds per client and re-read the store each time, so "real-time" was really "within 2s", and idle dashboards kept querying the backend forever.

Wrap now decorates the store with store.WithNotify — a small subscription hub that signals after every successful Add (buffered channel, bursts coalesce). The SSE handler subscribes and pushes appends as they happen; the ticker drops to a 15-second heartbeat that doubles as the clear/rollover resync safety net. A handler given a non-notifying store falls back to the old 2s cadence.

The notifier is public API on purpose: the planned MCP await_request tool needs exactly this hook.

Tests cover the notifier semantics (signal, coalescing, cancel) and an end-to-end SSE test that fails if an append has to wait for the ticker.