### PR TITLE
Add WithSampleRate for capture on busy services

### DIFF
--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"math/rand/v2"
 	"net"
 	"net/http"
 	"sync"
@@ -139,15 +140,22 @@ func readBodyCapped(r io.Reader, maxBody int) ([]byte, bool, error) {
 
 // Wrap wraps an http.Handler with the request visualization middleware
 func Wrap(handler http.Handler, st store.Store, logRequestBody, logResponseBody bool, pathMatcher PathMatcher) http.Handler {
-	return WrapWithLimits(handler, st, logRequestBody, logResponseBody, pathMatcher, DefaultMaxBodyBytes)
+	return WrapWithLimits(handler, st, logRequestBody, logResponseBody, pathMatcher, DefaultMaxBodyBytes, 1)
 }
 
 // WrapWithLimits is identical to Wrap but allows the caller to specify the maximum number of
-// captured body bytes (per request and per response). A value <= 0 disables the cap.
-func WrapWithLimits(handler http.Handler, st store.Store, logRequestBody, logResponseBody bool, pathMatcher PathMatcher, maxBody int) http.Handler {
+// captured body bytes (per request and per response, <= 0 disables the cap)
+// and the sampling rate (0..1; requests that lose the coin toss pass through
+// uncaptured).
+func WrapWithLimits(handler http.Handler, st store.Store, logRequestBody, logResponseBody bool, pathMatcher PathMatcher, maxBody int, sampleRate float64) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Check if the path should be ignored
 		if pathMatcher != nil && pathMatcher.ShouldIgnorePath(r.URL.Path) {
+			handler.ServeHTTP(w, r)
+			return
+		}
+
+		if sampleRate < 1 && rand.Float64() >= sampleRate {
 			handler.ServeHTTP(w, r)
 			return
 		}

--- a/internal/middleware/profiling.go
+++ b/internal/middleware/profiling.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"bytes"
 	"io"
+	"math/rand/v2"
 	"net/http"
 	"time"
 
@@ -20,13 +21,18 @@ type ProfilingConfig struct {
 
 // WrapWithProfiling wraps an http.Handler with request visualization and performance profiling.
 func WrapWithProfiling(handler http.Handler, st store.Store, logRequestBody, logResponseBody bool, pathMatcher PathMatcher, profiler *profiling.Profiler) http.Handler {
-	return WrapWithProfilingAndLimits(handler, st, logRequestBody, logResponseBody, pathMatcher, profiler, DefaultMaxBodyBytes)
+	return WrapWithProfilingAndLimits(handler, st, logRequestBody, logResponseBody, pathMatcher, profiler, DefaultMaxBodyBytes, 1)
 }
 
 // WrapWithProfilingAndLimits is identical to WrapWithProfiling but exposes the captured-body size cap.
-func WrapWithProfilingAndLimits(handler http.Handler, st store.Store, logRequestBody, logResponseBody bool, pathMatcher PathMatcher, profiler *profiling.Profiler, maxBody int) http.Handler {
+func WrapWithProfilingAndLimits(handler http.Handler, st store.Store, logRequestBody, logResponseBody bool, pathMatcher PathMatcher, profiler *profiling.Profiler, maxBody int, sampleRate float64) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if pathMatcher != nil && pathMatcher.ShouldIgnorePath(r.URL.Path) {
+			handler.ServeHTTP(w, r)
+			return
+		}
+
+		if sampleRate < 1 && rand.Float64() >= sampleRate {
 			handler.ServeHTTP(w, r)
 			return
 		}

--- a/options.go
+++ b/options.go
@@ -33,6 +33,10 @@ type Config struct {
 
 	IgnorePaths []string
 
+	// SampleRate is the fraction of requests to capture, 0..1. 1 captures
+	// everything (the default); lower values shed load on chatty services.
+	SampleRate float64
+
 	// Store is the storage backend for captured requests. Nil means an
 	// in-memory store bounded by MaxRequests. Database-backed stores live in
 	// their own modules under store/ (postgres, redis, sqlite, mongodb).
@@ -121,6 +125,21 @@ func WithResponseBodyLogging(enabled bool) Option {
 func WithMaxBodyBytes(n int) Option {
 	return func(c *Config) {
 		c.MaxBodyBytes = n
+	}
+}
+
+// WithSampleRate captures only the given fraction of requests (0..1).
+// Uncaptured requests pass through with no overhead. Useful when govisual
+// wraps a busy service and full capture would be noise.
+func WithSampleRate(rate float64) Option {
+	return func(c *Config) {
+		if rate < 0 {
+			rate = 0
+		}
+		if rate > 1 {
+			rate = 1
+		}
+		c.SampleRate = rate
 	}
 }
 
@@ -275,18 +294,19 @@ func WithShutdownContext(ctx context.Context) Option {
 // defaultConfig returns the default configuration
 func defaultConfig() *Config {
 	return &Config{
-		MaxRequests:         100,
-		DashboardPath:       "/__viz",
-		LogRequestBody:      false,
-		LogResponseBody:     false,
-		MaxBodyBytes:        0, // 0 => use middleware.DefaultMaxBodyBytes
-		IgnorePaths:         []string{},
-		EnableProfiling:     false,
-		ProfileType:         profiling.ProfileAll,
-		ProfileThreshold:    10 * time.Millisecond,
-		MaxProfileMetrics:   1000,
-		LocalhostOnly:       true,
-		EnableReplay:        false,
-		ExposeSystemInfo:    false,
+		MaxRequests:       100,
+		DashboardPath:     "/__viz",
+		LogRequestBody:    false,
+		LogResponseBody:   false,
+		MaxBodyBytes:      0, // 0 => use middleware.DefaultMaxBodyBytes
+		IgnorePaths:       []string{},
+		SampleRate:        1,
+		EnableProfiling:   false,
+		ProfileType:       profiling.ProfileAll,
+		ProfileThreshold:  10 * time.Millisecond,
+		MaxProfileMetrics: 1000,
+		LocalhostOnly:     true,
+		EnableReplay:      false,
+		ExposeSystemInfo:  false,
 	}
 }

--- a/wrap.go
+++ b/wrap.go
@@ -46,13 +46,13 @@ func Wrap(handler http.Handler, opts ...Option) http.Handler {
 		wrapped = middleware.WrapWithProfilingAndLimits(
 			handler, requestStore,
 			config.LogRequestBody, config.LogResponseBody,
-			config, profiler, config.effectiveMaxBody(),
+			config, profiler, config.effectiveMaxBody(), config.SampleRate,
 		)
 	} else {
 		wrapped = middleware.WrapWithLimits(
 			handler, requestStore,
 			config.LogRequestBody, config.LogResponseBody,
-			config, config.effectiveMaxBody(),
+			config, config.effectiveMaxBody(), config.SampleRate,
 		)
 	}
 

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -3,6 +3,7 @@ package govisual
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -31,5 +32,44 @@ func TestDashboardLocalhostOnlyByDefault(t *testing.T) {
 func TestDashboardAllowRemote(t *testing.T) {
 	if got := dashboardStatus(t, "203.0.113.7:5555", WithAllowRemote()); got != http.StatusOK {
 		t.Fatalf("remote request with WithAllowRemote: got %d, want 200", got)
+	}
+}
+
+func capturedRequests(t *testing.T, h http.Handler) string {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/__viz/api/requests", nil)
+	req.RemoteAddr = "127.0.0.1:5555"
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec.Body.String()
+}
+
+func TestSampleRateZeroCapturesNothing(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {})
+	h := Wrap(mux, WithSampleRate(0))
+
+	for i := 0; i < 5; i++ {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/hello", nil))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("sampled-out request must still be served, got %d", rec.Code)
+		}
+	}
+
+	if body := capturedRequests(t, h); strings.Contains(body, "/hello") {
+		t.Fatalf("sample rate 0 captured requests: %s", body)
+	}
+}
+
+func TestSampleRateDefaultCapturesEverything(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {})
+	h := Wrap(mux)
+
+	h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/hello", nil))
+
+	if body := capturedRequests(t, h); !strings.Contains(body, "/hello") {
+		t.Fatalf("default sampling missed a request: %s", body)
 	}
 }


### PR DESCRIPTION
WithSampleRate(0.1) captures a tenth of the traffic; everything else passes straight through with no body buffering, tracing, or store write. Rate is clamped to 0..1 and defaults to 1, so nothing changes unless asked. Applies to both the plain and the profiling middleware, after the ignore-path check.

Tests pin the two edges: rate 0 serves but captures nothing, default captures everything.