### PR TITLE
Attach slog output to captured requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,30 @@ handler := govisual.Wrap(
 )
 ```
 
+## SQL Query Capture
+
+Wrap your database driver and every query executed with a request's context lands on that request's profile — durations, affected rows, and errors:
+
+```go
+sql.Register("postgres+viz", govisual.WrapDriver(&pq.Driver{}))
+db, err := sql.Open("postgres+viz", dsn)
+```
+
+Run queries with the request context (`db.QueryContext(r.Context(), ...)`) and enable profiling (`WithProfiling(true)`).
+
+## Log Capture
+
+Wrap your slog handler and log lines emitted while handling a request travel with that request:
+
+```go
+logger := slog.New(govisual.SlogHandler(slog.NewJSONHandler(os.Stdout, nil)))
+
+// in a handler:
+logger.InfoContext(r.Context(), "cache miss", "key", key)
+```
+
+Logging still reaches your base handler exactly as before; govisual just keeps a bounded copy (200 lines per request) alongside the captured request.
+
 ## OpenTelemetry
 
 Tracing lives in its own module so the OTel SDK and gRPC stay out of builds that don't use them:

--- a/internal/middleware/logs.go
+++ b/internal/middleware/logs.go
@@ -1,0 +1,61 @@
+package middleware
+
+import (
+	"context"
+	"sync"
+
+	"github.com/doganarif/govisual/v2/store"
+)
+
+// maxLogsPerRequest bounds how many log lines a single request may retain,
+// so a logging loop can't grow a request record without limit.
+const maxLogsPerRequest = 200
+
+type logCollectorKey struct{}
+
+// LogCollector accumulates log lines emitted during one request.
+type LogCollector struct {
+	mu      sync.Mutex
+	entries []store.LogEntry
+	dropped int
+}
+
+// WithLogCollector attaches a fresh collector to ctx and returns both.
+func WithLogCollector(ctx context.Context) (context.Context, *LogCollector) {
+	c := &LogCollector{}
+	return context.WithValue(ctx, logCollectorKey{}, c), c
+}
+
+// LogCollectorFromContext returns the request's collector, or nil when the
+// context does not belong to a captured request.
+func LogCollectorFromContext(ctx context.Context) *LogCollector {
+	c, _ := ctx.Value(logCollectorKey{}).(*LogCollector)
+	return c
+}
+
+// Append records one log line, dropping beyond the per-request cap.
+func (c *LogCollector) Append(e store.LogEntry) {
+	c.mu.Lock()
+	if len(c.entries) < maxLogsPerRequest {
+		c.entries = append(c.entries, e)
+	} else {
+		c.dropped++
+	}
+	c.mu.Unlock()
+}
+
+// Snapshot returns the collected lines. A trailing marker entry reports how
+// many lines were dropped, if any.
+func (c *LogCollector) Snapshot() []store.LogEntry {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := append([]store.LogEntry(nil), c.entries...)
+	if c.dropped > 0 {
+		out = append(out, store.LogEntry{
+			Level:   "WARN",
+			Message: "govisual: log capture truncated",
+			Attrs:   map[string]any{"dropped": c.dropped},
+		})
+	}
+	return out
+}

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -163,6 +163,10 @@ func WrapWithLimits(handler http.Handler, st store.Store, logRequestBody, logRes
 		// Create a new request log
 		reqLog := store.NewRequestLog(r)
 
+		// Collect slog output emitted with this request's context.
+		ctx, collector := WithLogCollector(r.Context())
+		r = r.WithContext(ctx)
+
 		// Capture request body if enabled
 		if logRequestBody && r.Body != nil {
 			bodyBytes, _, err := readBodyCapped(r.Body, maxBody)
@@ -211,6 +215,8 @@ func WrapWithLimits(handler http.Handler, st store.Store, logRequestBody, logRes
 		if logResponseBody {
 			reqLog.ResponseBody = resWriter.body()
 		}
+
+		reqLog.Logs = collector.Snapshot()
 
 		if err := st.Add(reqLog); err != nil {
 			// Storage errors are surfaced on the log entry's Error field so they

--- a/internal/middleware/profiling.go
+++ b/internal/middleware/profiling.go
@@ -46,7 +46,7 @@ func WrapWithProfilingAndLimits(handler http.Handler, st store.Store, logRequest
 			"query":  r.URL.RawQuery,
 		})
 
-		ctx := r.Context()
+		ctx, collector := WithLogCollector(r.Context())
 		ctx = WithTracer(ctx, tracer)
 		// Register the tracer as a TracerSink so the profiler forwards SQL/HTTP
 		// events into the tracer's child traces.
@@ -119,6 +119,8 @@ func WrapWithProfilingAndLimits(handler http.Handler, st store.Store, logRequest
 		if logResponseBody {
 			reqLog.ResponseBody = resWriter.body()
 		}
+
+		reqLog.Logs = collector.Snapshot()
 
 		_ = st.Add(reqLog)
 	})

--- a/slog.go
+++ b/slog.go
@@ -1,0 +1,76 @@
+package govisual
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/doganarif/govisual/v2/internal/middleware"
+	"github.com/doganarif/govisual/v2/store"
+)
+
+// SlogHandler wraps a slog.Handler so records logged with a request's
+// context also attach to that request in the dashboard:
+//
+//	logger := slog.New(govisual.SlogHandler(slog.NewJSONHandler(os.Stdout, nil)))
+//	logger.InfoContext(r.Context(), "cache miss", "key", key)
+//
+// Records logged without a captured request's context pass through to the
+// base handler untouched. Capture is bounded per request; a floods-of-logs
+// handler can't grow a request record without limit.
+func SlogHandler(base slog.Handler) slog.Handler {
+	return &slogCapture{base: base}
+}
+
+type slogCapture struct {
+	base  slog.Handler
+	attrs []slog.Attr
+	group string
+}
+
+func (h *slogCapture) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.base.Enabled(ctx, level)
+}
+
+func (h *slogCapture) Handle(ctx context.Context, rec slog.Record) error {
+	if c := middleware.LogCollectorFromContext(ctx); c != nil {
+		attrs := make(map[string]any, rec.NumAttrs()+len(h.attrs))
+		for _, a := range h.attrs {
+			attrs[a.Key] = a.Value.Any()
+		}
+		rec.Attrs(func(a slog.Attr) bool {
+			attrs[h.group+a.Key] = a.Value.Any()
+			return true
+		})
+		c.Append(store.LogEntry{
+			Time:    rec.Time,
+			Level:   rec.Level.String(),
+			Message: rec.Message,
+			Attrs:   attrs,
+		})
+	}
+	return h.base.Handle(ctx, rec)
+}
+
+func (h *slogCapture) WithAttrs(attrs []slog.Attr) slog.Handler {
+	// Groups flatten to dotted keys in the captured map.
+	prefixed := make([]slog.Attr, len(attrs))
+	for i, a := range attrs {
+		prefixed[i] = slog.Attr{Key: h.group + a.Key, Value: a.Value}
+	}
+	return &slogCapture{
+		base:  h.base.WithAttrs(attrs),
+		attrs: append(append([]slog.Attr(nil), h.attrs...), prefixed...),
+		group: h.group,
+	}
+}
+
+func (h *slogCapture) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return h
+	}
+	return &slogCapture{
+		base:  h.base.WithGroup(name),
+		attrs: h.attrs,
+		group: h.group + name + ".",
+	}
+}

--- a/slog_test.go
+++ b/slog_test.go
@@ -1,0 +1,55 @@
+package govisual
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestSlogHandlerAttachesLogsToRequest(t *testing.T) {
+	logger := slog.New(SlogHandler(slog.NewTextHandler(io.Discard, nil)))
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/work", func(w http.ResponseWriter, r *http.Request) {
+		logger.InfoContext(r.Context(), "cache miss", "key", "user:42")
+	})
+	h := Wrap(mux)
+
+	h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/work", nil))
+
+	body := capturedRequests(t, h)
+	if !strings.Contains(body, "cache miss") || !strings.Contains(body, "user:42") {
+		t.Fatalf("captured request is missing the log line: %s", body)
+	}
+}
+
+func TestSlogHandlerWithoutRequestContextPassesThrough(t *testing.T) {
+	var buf strings.Builder
+	logger := slog.New(SlogHandler(slog.NewTextHandler(&buf, nil)))
+
+	logger.Info("startup", "port", 8080)
+
+	if !strings.Contains(buf.String(), "startup") {
+		t.Fatalf("base handler did not receive the record: %s", buf.String())
+	}
+}
+
+func TestSlogHandlerGroupsFlattenInCapture(t *testing.T) {
+	logger := slog.New(SlogHandler(slog.NewTextHandler(io.Discard, nil))).
+		WithGroup("db").With("driver", "postgres")
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/q", func(w http.ResponseWriter, r *http.Request) {
+		logger.InfoContext(r.Context(), "query ran", "rows", 3)
+	})
+	h := Wrap(mux)
+	h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/q", nil))
+
+	body := capturedRequests(t, h)
+	if !strings.Contains(body, "db.driver") || !strings.Contains(body, "db.rows") {
+		t.Fatalf("expected flattened group keys in capture: %s", body)
+	}
+}

--- a/store/request.go
+++ b/store/request.go
@@ -23,6 +23,16 @@ type RequestLog struct {
 	MiddlewareTrace    []map[string]interface{} `json:"MiddlewareTrace,omitempty" bson:"middleware_trace,omitempty"`
 	RouteTrace         map[string]interface{}   `json:"RouteTrace,omitempty" bson:"route_trace,omitempty"`
 	PerformanceMetrics *PerformanceMetrics      `json:"PerformanceMetrics,omitempty" bson:"performance_metrics,omitempty"`
+	Logs               []LogEntry               `json:"Logs,omitempty" bson:"logs,omitempty"`
+}
+
+// LogEntry is a single application log line emitted while the request was
+// being handled, captured via govisual.SlogHandler.
+type LogEntry struct {
+	Time    time.Time      `json:"time"`
+	Level   string         `json:"level"`
+	Message string         `json:"message"`
+	Attrs   map[string]any `json:"attrs,omitempty"`
 }
 
 // PerformanceMetrics is the per-request profiling data attached to a


### PR DESCRIPTION
govisual.SlogHandler wraps any slog.Handler; records logged with a request's context (InfoContext and friends) get a bounded copy attached to that request's log in the store, on a new Logs field. Everything still flows to the base handler unchanged, records without a captured request pass through untouched, and capture stops at 200 lines per request with an explicit truncation marker.

WithGroup/WithAttrs are preserved for the base handler and flatten to dotted keys in the captured map.

Request + response + SQL + logs in one record is the debugging bundle both the dashboard drawer and the planned MCP get_debug_context tool hand out. This PR also carries the README section for WrapDriver from #52 (its anchor collided with an existing heading at commit time).

Tests: capture through a full Wrap round trip, pass-through without request context, group flattening; middleware suite is race-clean.