### PR TITLE
Capture handler panics with their stack

### DIFF
--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -5,10 +5,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"math/rand/v2"
 	"net"
 	"net/http"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -84,6 +86,13 @@ func (w *responseWriter) status() int {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	return w.statusCode
+}
+
+// wrote reports whether the handler wrote a response header.
+func (w *responseWriter) wrote() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.wroteHeader
 }
 
 // body returns a snapshot of the captured response body, or "" when body
@@ -189,40 +198,61 @@ func WrapWithLimits(handler http.Handler, st store.Store, logRequestBody, logRes
 		}
 
 		start := time.Now()
+		finish := func(panicked bool) {
+			reqLog.Duration = time.Since(start).Milliseconds()
+			reqLog.StatusCode = resWriter.status()
+			if panicked && !resWriter.wrote() {
+				// The handler died before writing; the client effectively
+				// sees a failed request.
+				reqLog.StatusCode = http.StatusInternalServerError
+			}
+
+			// Extract user-provided middleware-stack information from context
+			if v := r.Context().Value(MiddlewareStackKey{}); v != nil {
+				if middlewareInfo, ok := v.(map[string]interface{}); ok {
+					if stack, ok := middlewareInfo["stack"].([]map[string]interface{}); ok {
+						reqLog.MiddlewareTrace = stack
+					}
+				}
+			}
+
+			// Extract route trace information
+			if v := r.Context().Value(RouteTraceKey{}); v != nil {
+				if routeStr, ok := v.(string); ok {
+					var routeInfo map[string]interface{}
+					if err := json.Unmarshal([]byte(routeStr), &routeInfo); err == nil {
+						reqLog.RouteTrace = routeInfo
+					}
+				}
+			}
+
+			if logResponseBody {
+				reqLog.ResponseBody = resWriter.body()
+			}
+
+			reqLog.Logs = collector.Snapshot()
+
+			addToStore(st, reqLog)
+		}
+
+		defer func() {
+			if rec := recover(); rec != nil {
+				reqLog.Error = fmt.Sprintf("panic: %v", rec)
+				reqLog.PanicStack = string(debug.Stack())
+				finish(true)
+				// Re-panic so recovery middleware and net/http behave exactly
+				// as they would without govisual in the chain.
+				panic(rec)
+			}
+		}()
+
 		handler.ServeHTTP(resWriter, r)
-		reqLog.Duration = time.Since(start).Milliseconds()
-		reqLog.StatusCode = resWriter.status()
-
-		// Extract user-provided middleware-stack information from context
-		if v := r.Context().Value(MiddlewareStackKey{}); v != nil {
-			if middlewareInfo, ok := v.(map[string]interface{}); ok {
-				if stack, ok := middlewareInfo["stack"].([]map[string]interface{}); ok {
-					reqLog.MiddlewareTrace = stack
-				}
-			}
-		}
-
-		// Extract route trace information
-		if v := r.Context().Value(RouteTraceKey{}); v != nil {
-			if routeStr, ok := v.(string); ok {
-				var routeInfo map[string]interface{}
-				if err := json.Unmarshal([]byte(routeStr), &routeInfo); err == nil {
-					reqLog.RouteTrace = routeInfo
-				}
-			}
-		}
-
-		if logResponseBody {
-			reqLog.ResponseBody = resWriter.body()
-		}
-
-		reqLog.Logs = collector.Snapshot()
-
-		if err := st.Add(reqLog); err != nil {
-			// Storage errors are surfaced on the log entry's Error field so they
-			// remain visible to anyone inspecting the dashboard backend; we do
-			// not block the request path.
-			_ = err
-		}
+		finish(false)
 	})
+}
+
+// addToStore persists the entry. Storage errors are deliberately not allowed
+// to block or fail the request path.
+func addToStore(st store.Store, reqLog *store.RequestLog) {
+	_ = st.Add(reqLog)
 }

--- a/internal/middleware/profiling.go
+++ b/internal/middleware/profiling.go
@@ -2,9 +2,11 @@ package middleware
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"math/rand/v2"
 	"net/http"
+	"runtime/debug"
 	"time"
 
 	"github.com/doganarif/govisual/v2/internal/profiling"
@@ -76,53 +78,73 @@ func WrapWithProfilingAndLimits(handler http.Handler, st store.Store, logRequest
 		}
 
 		start := time.Now()
-		handler.ServeHTTP(resWriter, r)
-		reqLog.Duration = time.Since(start).Milliseconds()
+		finish := func(panicErr error) {
+			reqLog.Duration = time.Since(start).Milliseconds()
 
-		if profiler != nil {
-			if metrics := profiler.EndProfiling(ctx); metrics != nil {
-				reqLog.PerformanceMetrics = metrics.Model()
-			}
-		}
-
-		reqLog.StatusCode = resWriter.status()
-
-		tracer.EndTrace(nil)
-		tracer.Complete()
-
-		reqLog.MiddlewareTrace = make([]map[string]interface{}, 0)
-		for _, trace := range tracer.GetTraces() {
-			traceMap := map[string]interface{}{
-				"name":       trace.Name,
-				"type":       trace.Type,
-				"start_time": trace.StartTime,
-				"end_time":   trace.EndTime,
-				"duration":   trace.Duration.Milliseconds(),
-				"status":     trace.Status,
-				"details":    trace.Details,
-				"children":   trace.Children,
-			}
-			if trace.Error != "" {
-				traceMap["error"] = trace.Error
-			}
-			reqLog.MiddlewareTrace = append(reqLog.MiddlewareTrace, traceMap)
-		}
-
-		if v := r.Context().Value(MiddlewareStackKey{}); v != nil {
-			if middlewareInfo, ok := v.(map[string]interface{}); ok {
-				if stack, ok := middlewareInfo["stack"].([]map[string]interface{}); ok {
-					reqLog.MiddlewareTrace = append(reqLog.MiddlewareTrace, stack...)
+			if profiler != nil {
+				if metrics := profiler.EndProfiling(ctx); metrics != nil {
+					reqLog.PerformanceMetrics = metrics.Model()
 				}
 			}
+
+			reqLog.StatusCode = resWriter.status()
+			if panicErr != nil && !resWriter.wrote() {
+				// The handler died before writing; the client effectively
+				// sees a failed request.
+				reqLog.StatusCode = http.StatusInternalServerError
+			}
+
+			tracer.EndTrace(panicErr)
+			tracer.Complete()
+
+			reqLog.MiddlewareTrace = make([]map[string]interface{}, 0)
+			for _, trace := range tracer.GetTraces() {
+				traceMap := map[string]interface{}{
+					"name":       trace.Name,
+					"type":       trace.Type,
+					"start_time": trace.StartTime,
+					"end_time":   trace.EndTime,
+					"duration":   trace.Duration.Milliseconds(),
+					"status":     trace.Status,
+					"details":    trace.Details,
+					"children":   trace.Children,
+				}
+				if trace.Error != "" {
+					traceMap["error"] = trace.Error
+				}
+				reqLog.MiddlewareTrace = append(reqLog.MiddlewareTrace, traceMap)
+			}
+
+			if v := r.Context().Value(MiddlewareStackKey{}); v != nil {
+				if middlewareInfo, ok := v.(map[string]interface{}); ok {
+					if stack, ok := middlewareInfo["stack"].([]map[string]interface{}); ok {
+						reqLog.MiddlewareTrace = append(reqLog.MiddlewareTrace, stack...)
+					}
+				}
+			}
+
+			if logResponseBody {
+				reqLog.ResponseBody = resWriter.body()
+			}
+
+			reqLog.Logs = collector.Snapshot()
+
+			_ = st.Add(reqLog)
 		}
 
-		if logResponseBody {
-			reqLog.ResponseBody = resWriter.body()
-		}
+		defer func() {
+			if rec := recover(); rec != nil {
+				reqLog.Error = fmt.Sprintf("panic: %v", rec)
+				reqLog.PanicStack = string(debug.Stack())
+				finish(fmt.Errorf("panic: %v", rec))
+				// Re-panic so recovery middleware and net/http behave exactly
+				// as they would without govisual in the chain.
+				panic(rec)
+			}
+		}()
 
-		reqLog.Logs = collector.Snapshot()
-
-		_ = st.Add(reqLog)
+		handler.ServeHTTP(resWriter, r)
+		finish(nil)
 	})
 }
 

--- a/store/request.go
+++ b/store/request.go
@@ -24,6 +24,7 @@ type RequestLog struct {
 	RouteTrace         map[string]interface{}   `json:"RouteTrace,omitempty" bson:"route_trace,omitempty"`
 	PerformanceMetrics *PerformanceMetrics      `json:"PerformanceMetrics,omitempty" bson:"performance_metrics,omitempty"`
 	Logs               []LogEntry               `json:"Logs,omitempty" bson:"logs,omitempty"`
+	PanicStack         string                   `json:"PanicStack,omitempty" bson:"panic_stack,omitempty"`
 }
 
 // LogEntry is a single application log line emitted while the request was

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -73,3 +73,53 @@ func TestSampleRateDefaultCapturesEverything(t *testing.T) {
 		t.Fatalf("default sampling missed a request: %s", body)
 	}
 }
+
+func TestPanicIsCapturedAndRepropagated(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/boom", func(w http.ResponseWriter, r *http.Request) {
+		panic("kaboom")
+	})
+	h := Wrap(mux)
+
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Fatal("panic must propagate through govisual")
+			}
+		}()
+		h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/boom", nil))
+	}()
+
+	body := capturedRequests(t, h)
+	if !strings.Contains(body, "panic: kaboom") {
+		t.Fatalf("panic not recorded: %s", body)
+	}
+	if !strings.Contains(body, "PanicStack") || !strings.Contains(body, "boom") {
+		t.Fatalf("stack not recorded: %s", body)
+	}
+	if !strings.Contains(body, `"StatusCode":500`) {
+		t.Fatalf("expected 500 on panicked request: %s", body)
+	}
+}
+
+func TestPanicIsCapturedWithProfiling(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/boom", func(w http.ResponseWriter, r *http.Request) {
+		panic("kaboom")
+	})
+	h := Wrap(mux, WithProfiling(true))
+
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Fatal("panic must propagate through govisual")
+			}
+		}()
+		h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/boom", nil))
+	}()
+
+	body := capturedRequests(t, h)
+	if !strings.Contains(body, "panic: kaboom") || !strings.Contains(body, `"StatusCode":500`) {
+		t.Fatalf("panic not recorded under profiling: %s", body)
+	}
+}


### PR DESCRIPTION
A panicking handler now leaves a full crime scene on the captured request: Error carries the panic value, the new PanicStack field carries the stack from the panic site, the status records as 500 when the handler died before writing, and the middleware trace closes with the panic as its error.

Crucially the panic is re-raised after recording, so recovery middleware and net/http's own connection handling behave exactly as they would without govisual in the chain — this is capture, not a recovery layer.

Both middleware paths got their post-handler block folded into a single finish() used by the normal return and the recover path, so panicked requests get the same duration/logs/trace treatment as everything else.

Tests assert capture and propagation for both the plain and profiling paths.