### PR TITLE
Add govisual.Event for annotating captured requests

### DIFF
--- a/event.go
+++ b/event.go
@@ -1,0 +1,40 @@
+package govisual
+
+import (
+	"context"
+	"time"
+
+	"github.com/doganarif/govisual/v2/internal/middleware"
+	"github.com/doganarif/govisual/v2/store"
+)
+
+// Event annotates the current request with a named application event:
+//
+//	govisual.Event(r.Context(), "cache miss", "key", key, "tier", "redis")
+//
+// The event shows up in the request's log timeline, and in the middleware
+// trace when profiling is enabled. Key/value pairs follow the slog
+// convention; a call outside a captured request is a no-op.
+func Event(ctx context.Context, name string, kv ...any) {
+	var attrs map[string]any
+	if len(kv) > 1 {
+		attrs = make(map[string]any, len(kv)/2)
+		for i := 0; i+1 < len(kv); i += 2 {
+			if k, ok := kv[i].(string); ok {
+				attrs[k] = kv[i+1]
+			}
+		}
+	}
+
+	if c := middleware.LogCollectorFromContext(ctx); c != nil {
+		c.Append(store.LogEntry{
+			Time:    time.Now(),
+			Level:   "EVENT",
+			Message: name,
+			Attrs:   attrs,
+		})
+	}
+	if tracer := middleware.GetTracer(ctx); tracer != nil {
+		tracer.RecordCustom(name, attrs)
+	}
+}

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -123,3 +123,22 @@ func TestPanicIsCapturedWithProfiling(t *testing.T) {
 		t.Fatalf("panic not recorded under profiling: %s", body)
 	}
 }
+
+func TestEventAttachesToRequest(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/work", func(w http.ResponseWriter, r *http.Request) {
+		Event(r.Context(), "cache miss", "key", "user:7")
+	})
+	h := Wrap(mux)
+
+	h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/work", nil))
+
+	body := capturedRequests(t, h)
+	if !strings.Contains(body, "cache miss") || !strings.Contains(body, "user:7") {
+		t.Fatalf("event not attached: %s", body)
+	}
+}
+
+func TestEventOutsideRequestIsNoOp(t *testing.T) {
+	Event(t.Context(), "orphan event", "k", "v")
+}


### PR DESCRIPTION
Event(ctx, name, kv...) drops a named marker on the current request — it lands in the request's log timeline, and in the middleware trace when profiling is on. The tracer's RecordCustom has existed since the tracing work but was unreachable from application code (the tracing example imported an internal package to get at it); this is the public door.

Key/value pairs follow slog convention, calls outside a captured request are a no-op.