### PR TITLE
Fix missed SSE pushes between snapshot and subscribe

### DIFF
--- a/internal/dashboard/handler.go
+++ b/internal/dashboard/handler.go
@@ -193,19 +193,20 @@ func (h *Handler) handleSSE(w http.ResponseWriter, r *http.Request) {
 		return true
 	}
 
-	initial := h.store.GetAll()
-	if !writeEvent("snapshot", initial) {
-		return
-	}
-
 	// When the store is notifying (the default via Wrap), new entries are
 	// pushed as they arrive; the ticker degrades to a heartbeat and a
-	// safety-net resync.
+	// safety-net resync. Subscribe before taking the snapshot so an Add in
+	// between is never silently missed — it just triggers one no-op flush.
 	var notify <-chan struct{}
 	if ns, ok := h.store.(*store.NotifyingStore); ok {
 		ch, cancel := ns.Subscribe()
 		defer cancel()
 		notify = ch
+	}
+
+	initial := h.store.GetAll()
+	if !writeEvent("snapshot", initial) {
+		return
 	}
 	tick := 15 * time.Second
 	if notify == nil {


### PR DESCRIPTION
The SSE handler subscribed to store notifications after sending the initial snapshot. An Add landing in that window was silently missed and only surfaced at the 15-second resync — the flaky TestSSEPushesOnAdd failure on #55's CI run was exactly this race under load.

Subscribing before taking the snapshot closes the window: an Add in between now shows up in the snapshot and additionally triggers one no-op flush.