### PR TITLE
Expose outbound HTTP capture via govisual.WrapTransport

### DIFF
--- a/internal/profiling/profiler.go
+++ b/internal/profiling/profiler.go
@@ -419,7 +419,13 @@ func (p *Profiler) RecordHTTPCall(ctx context.Context, method, url string, durat
 	if !p.enabled.Load() {
 		return
 	}
+	RecordHTTP(ctx, method, url, duration, status, size)
+}
 
+// RecordHTTP attaches an outbound HTTP call to the request profile carried
+// by ctx. Without an active profile it is a no-op, so it is safe to call
+// unconditionally — this is what the WrapTransport instrumentation uses.
+func RecordHTTP(ctx context.Context, method, url string, duration time.Duration, status int, size int64) {
 	metrics, ok := ctx.Value(profileContextKey{}).(*Metrics)
 	if !ok || metrics == nil {
 		return

--- a/internal/profiling/sqlhook_test.go
+++ b/internal/profiling/sqlhook_test.go
@@ -67,3 +67,24 @@ func TestWrapDriverNoProfileIsNoOp(t *testing.T) {
 		t.Fatalf("exec: %v", err)
 	}
 }
+
+func TestRecordHTTPAttachesToProfile(t *testing.T) {
+	profiler := NewProfiler(10)
+	profiler.SetProfileType(ProfileMemory)
+	profiler.SetThreshold(0)
+	ctx := profiler.StartProfiling(context.Background(), "req-http")
+
+	RecordHTTP(ctx, "GET", "https://api.example.com/users", 42*time.Millisecond, 200, 512)
+
+	metrics := profiler.EndProfiling(ctx)
+	if metrics == nil {
+		t.Fatal("expected metrics")
+	}
+	if len(metrics.HTTPCalls) != 1 {
+		t.Fatalf("expected 1 recorded call, got %d", len(metrics.HTTPCalls))
+	}
+	c := metrics.HTTPCalls[0]
+	if c.URL != "https://api.example.com/users" || c.Status != 200 || c.Size != 512 {
+		t.Fatalf("recorded call = %+v", c)
+	}
+}

--- a/transport.go
+++ b/transport.go
@@ -1,0 +1,45 @@
+package govisual
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/doganarif/govisual/v2/internal/profiling"
+)
+
+// WrapTransport instruments an http.RoundTripper so outbound calls made
+// while handling a request show up on that request's profile:
+//
+//	client := &http.Client{Transport: govisual.WrapTransport(nil)}
+//	resp, err := client.Do(req.WithContext(r.Context()))
+//
+// Attribution goes through the request context, so outbound requests must
+// carry it, and profiling must be enabled via WithProfiling(true). A nil rt
+// wraps http.DefaultTransport.
+func WrapTransport(rt http.RoundTripper) http.RoundTripper {
+	if rt == nil {
+		rt = http.DefaultTransport
+	}
+	return &vizTransport{base: rt}
+}
+
+type vizTransport struct {
+	base http.RoundTripper
+}
+
+func (t *vizTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	start := time.Now()
+	resp, err := t.base.RoundTrip(req)
+	duration := time.Since(start)
+
+	status := 0
+	size := int64(0)
+	if resp != nil {
+		status = resp.StatusCode
+		if resp.ContentLength > 0 {
+			size = resp.ContentLength
+		}
+	}
+	profiling.RecordHTTP(req.Context(), req.Method, req.URL.String(), duration, status, size)
+	return resp, err
+}


### PR DESCRIPTION
Same story as WrapDriver in #52: the outbound-call recording existed (HTTPRoundTripper) but needed a profiler handle only Wrap ever held. Recording now goes through the request context, and govisual.WrapTransport(rt) wraps any RoundTripper — outbound calls made while handling a request land on that request's profile with method, URL, duration, status and size, feeding the existing http_calls view and the external-call bottleneck analysis.

Passing nil wraps http.DefaultTransport. Calls without a profiled request context pass through untouched.