### PR TITLE
MCP server: captured traffic as tools for coding agents

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
           REDIS_CONN: redis://localhost:6379/0
           MONGO_URI: mongodb://root:root@localhost:27017
         run: |
-          for m in store/postgres store/redis store/mongodb store/sqlite telemetry; do
+          for m in store/postgres store/redis store/mongodb store/sqlite telemetry mcp; do
             echo "== $m"
             (cd "$m" && go test -v ./...)
           done

--- a/README.md
+++ b/README.md
@@ -87,6 +87,30 @@ handler := govisual.Wrap(
 )
 ```
 
+## MCP: Let Your Coding Agent Debug
+
+The `mcp` module serves captured traffic to AI coding agents over the Model Context Protocol. Claude Code (or any MCP client) can list requests, pull full debug context — headers, bodies, logs, SQL, panic stacks — replay requests against your running app, and `diff_replay` a request after a fix to verify the behavior actually changed.
+
+```bash
+go get github.com/doganarif/govisual/mcp
+```
+
+```go
+st := store.NewMemory(200)
+app := govisual.Wrap(mux, govisual.WithStore(st))
+
+root := http.NewServeMux()
+root.Handle("/mcp", gvmcp.Handler(st, gvmcp.WithBaseURL("http://localhost:8080")))
+root.Handle("/", app)
+http.ListenAndServe(":8080", root)
+```
+
+```bash
+claude mcp add govisual --transport http http://localhost:8080/mcp
+```
+
+Tools: `get_last_error`, `list_requests`, `get_request`, `search_requests`, `get_stats`, `get_debug_context`, `replay_request`, `diff_replay`. Responses are token-aware (bounded lists, capped body excerpts). The endpoint is loopback-only by default and replays can only target your own app, never arbitrary hosts.
+
 ## SQL Query Capture
 
 Wrap your database driver and every query executed with a request's context lands on that request's profile — durations, affected rows, and errors:

--- a/mcp/go.mod
+++ b/mcp/go.mod
@@ -1,0 +1,15 @@
+module github.com/doganarif/govisual/mcp
+
+go 1.24.0
+
+require (
+	github.com/doganarif/govisual/v2 v2.0.0
+	github.com/modelcontextprotocol/go-sdk v1.0.0
+)
+
+require (
+	github.com/google/jsonschema-go v0.3.0 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
+)
+
+replace github.com/doganarif/govisual/v2 => ..

--- a/mcp/go.sum
+++ b/mcp/go.sum
@@ -1,0 +1,10 @@
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/jsonschema-go v0.3.0 h1:6AH2TxVNtk3IlvkkhjrtbUc4S8AvO0Xii0DxIygDg+Q=
+github.com/google/jsonschema-go v0.3.0/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
+github.com/modelcontextprotocol/go-sdk v1.0.0 h1:Z4MSjLi38bTgLrd/LjSmofqRqyBiVKRyQSJgw8q8V74=
+github.com/modelcontextprotocol/go-sdk v1.0.0/go.mod h1:nYtYQroQ2KQiM0/SbyEPUWQ6xs4B95gJjEalc9AQyOs=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
+golang.org/x/tools v0.34.0 h1:qIpSLOxeCYGg9TrcJokLBG4KFA6d795g0xkBkiESGlo=
+golang.org/x/tools v0.34.0/go.mod h1:pAP9OwEaY1CAW3HOmg3hLZC5Z0CCmzjAF2UQMSqNARg=

--- a/mcp/mcp.go
+++ b/mcp/mcp.go
@@ -1,0 +1,93 @@
+// Package mcp serves govisual's captured traffic to AI coding agents over
+// the Model Context Protocol. Mount the handler next to (not inside) the
+// wrapped application so agent traffic isn't captured as requests:
+//
+//	st := store.NewMemory(200)
+//	app := govisual.Wrap(mux, govisual.WithStore(st))
+//
+//	root := http.NewServeMux()
+//	root.Handle("/mcp", gvmcp.Handler(st, gvmcp.WithBaseURL("http://localhost:8080")))
+//	root.Handle("/", app)
+//
+// Then point a client at it: claude mcp add govisual --transport http http://localhost:8080/mcp
+package mcp
+
+import (
+	"net"
+	"net/http"
+
+	"github.com/doganarif/govisual/v2/store"
+	sdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type config struct {
+	baseURL     string
+	allowRemote bool
+	token       string
+}
+
+// Option configures the MCP handler.
+type Option func(*config)
+
+// WithBaseURL sets the URL replays are sent to. Replay always targets the
+// wrapped application — an agent can change method, path, headers, and body,
+// but never the destination host, so the endpoint is not an SSRF primitive.
+// Defaults to http://<captured Host> of the request being replayed.
+func WithBaseURL(u string) Option {
+	return func(c *config) { c.baseURL = u }
+}
+
+// WithAllowRemote lets non-loopback addresses use the MCP endpoint. Off by
+// default for the same reason the dashboard is loopback-only.
+func WithAllowRemote() Option {
+	return func(c *config) { c.allowRemote = true }
+}
+
+// WithToken requires a Bearer token on every MCP request. Recommended
+// whenever WithAllowRemote is used.
+func WithToken(token string) Option {
+	return func(c *config) { c.token = token }
+}
+
+// Handler returns the MCP endpoint for a govisual store. Use the same store
+// instance you passed to govisual.Wrap via WithStore.
+func Handler(st store.Store, opts ...Option) http.Handler {
+	cfg := &config{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	srv := newServer(st, cfg)
+	mcpHandler := sdk.NewStreamableHTTPHandler(func(*http.Request) *sdk.Server { return srv }, nil)
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !cfg.allowRemote && !isLoopback(r) {
+			http.Error(w, "forbidden", http.StatusForbidden)
+			return
+		}
+		if cfg.token != "" && r.Header.Get("Authorization") != "Bearer "+cfg.token {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		mcpHandler.ServeHTTP(w, r)
+	})
+}
+
+func newServer(st store.Store, cfg *config) *sdk.Server {
+	srv := sdk.NewServer(&sdk.Implementation{Name: "govisual", Version: "2.0.0"}, nil)
+	registerReadTools(srv, st)
+	registerReplayTools(srv, st, cfg)
+	return srv
+}
+
+func isLoopback(r *http.Request) bool {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		host = r.RemoteAddr
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	return ip.IsLoopback()
+}

--- a/mcp/mcp_test.go
+++ b/mcp/mcp_test.go
@@ -1,0 +1,209 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/doganarif/govisual/v2/store"
+	sdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func seedStore(t *testing.T) store.Store {
+	t.Helper()
+	st := store.NewMemory(50)
+	base := time.Now().Add(-time.Minute)
+	st.Add(&store.RequestLog{
+		ID: "ok-1", Timestamp: base, Method: "GET", Path: "/api/users",
+		StatusCode: 200, Duration: 12, Host: "localhost:8080",
+	})
+	st.Add(&store.RequestLog{
+		ID: "ok-2", Timestamp: base.Add(time.Second), Method: "POST", Path: "/api/users",
+		StatusCode: 201, Duration: 30, RequestBody: `{"name":"alice"}`, Host: "localhost:8080",
+	})
+	st.Add(&store.RequestLog{
+		ID: "bad-1", Timestamp: base.Add(2 * time.Second), Method: "GET", Path: "/api/orders",
+		StatusCode: 500, Duration: 87, Error: "panic: nil map write", PanicStack: "goroutine 1 [running]: ...",
+		Logs: []store.LogEntry{{Time: base, Level: "ERROR", Message: "order lookup failed"}},
+		Host: "localhost:8080",
+	})
+	return st
+}
+
+func connect(t *testing.T, st store.Store, cfg *config) *sdk.ClientSession {
+	t.Helper()
+	if cfg == nil {
+		cfg = &config{}
+	}
+	srv := newServer(st, cfg)
+	ct, srvT := sdk.NewInMemoryTransports()
+
+	ctx := t.Context()
+	if _, err := srv.Connect(ctx, srvT, nil); err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	client := sdk.NewClient(&sdk.Implementation{Name: "test", Version: "0"}, nil)
+	session, err := client.Connect(ctx, ct, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { session.Close() })
+	return session
+}
+
+func call(t *testing.T, s *sdk.ClientSession, tool string, args any) map[string]any {
+	t.Helper()
+	res, err := s.CallTool(t.Context(), &sdk.CallToolParams{Name: tool, Arguments: args})
+	if err != nil {
+		t.Fatalf("%s: %v", tool, err)
+	}
+	if res.IsError {
+		t.Fatalf("%s returned tool error: %+v", tool, res.Content)
+	}
+	data, err := json.Marshal(res.StructuredContent)
+	if err != nil {
+		t.Fatalf("marshal structured content: %v", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(data, &out); err != nil {
+		// Some tools return arrays or strings; wrap them.
+		return map[string]any{"value": res.StructuredContent}
+	}
+	return out
+}
+
+func TestGetLastError(t *testing.T) {
+	s := connect(t, seedStore(t), nil)
+	out := call(t, s, "get_last_error", struct{}{})
+	if out["id"] != "bad-1" {
+		t.Fatalf("expected bad-1, got %v", out["id"])
+	}
+	if out["error"] != "panic: nil map write" {
+		t.Fatalf("expected panic error, got %v", out["error"])
+	}
+}
+
+func TestListRequestsErrorsOnly(t *testing.T) {
+	s := connect(t, seedStore(t), nil)
+	out := call(t, s, "list_requests", map[string]any{"errors_only": true})
+	reqs := out["requests"].([]any)
+	if len(reqs) != 1 {
+		t.Fatalf("expected 1 error request, got %d", len(reqs))
+	}
+}
+
+func TestSearchRequests(t *testing.T) {
+	s := connect(t, seedStore(t), nil)
+	out := call(t, s, "search_requests", map[string]any{"query": "alice"})
+	reqs := out["requests"].([]any)
+	if len(reqs) != 1 {
+		t.Fatalf("expected 1 match, got %d", len(reqs))
+	}
+}
+
+func TestGetDebugContext(t *testing.T) {
+	s := connect(t, seedStore(t), nil)
+	out := call(t, s, "get_debug_context", map[string]any{"id": "bad-1"})
+	report, _ := out["report"].(string)
+	for _, want := range []string{"GET /api/orders", "panic: nil map write", "order lookup failed", "Panic stack"} {
+		if !strings.Contains(report, want) {
+			t.Fatalf("report missing %q:\n%s", want, report)
+		}
+	}
+}
+
+func TestDiffReplayDetectsFix(t *testing.T) {
+	// The "fixed" app now returns 200 where the capture saw 500.
+	app := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"orders":[]}`))
+	}))
+	defer app.Close()
+
+	st := seedStore(t)
+	u, _ := url.Parse(app.URL)
+	s := connect(t, st, &config{baseURL: "http://" + u.Host})
+
+	out := call(t, s, "diff_replay", map[string]any{"id": "bad-1"})
+	if out["status_changed"] != true {
+		t.Fatalf("expected status change, got %+v", out)
+	}
+	if out["replay_status"].(float64) != 200 {
+		t.Fatalf("expected replay status 200, got %v", out["replay_status"])
+	}
+	summary := out["summary"].(string)
+	if !strings.Contains(summary, "500 -> 200") {
+		t.Fatalf("summary = %q", summary)
+	}
+}
+
+func TestReplayOverrides(t *testing.T) {
+	var got *http.Request
+	var gotBody string
+	app := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Clone(context.Background())
+		b := make([]byte, 1024)
+		n, _ := r.Body.Read(b)
+		gotBody = string(b[:n])
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer app.Close()
+
+	st := seedStore(t)
+	u, _ := url.Parse(app.URL)
+	s := connect(t, st, &config{baseURL: "http://" + u.Host})
+
+	out := call(t, s, "replay_request", map[string]any{
+		"id":      "ok-2",
+		"path":    "/api/users/7",
+		"headers": map[string]string{"X-Debug": "1"},
+		"body":    `{"name":"bob"}`,
+	})
+	if out["status"].(float64) != 202 {
+		t.Fatalf("expected 202, got %v", out["status"])
+	}
+	if got.URL.Path != "/api/users/7" || got.Header.Get("X-Debug") != "1" || gotBody != `{"name":"bob"}` {
+		t.Fatalf("overrides not applied: %s %v body=%q", got.URL.Path, got.Header, gotBody)
+	}
+	if got.Header.Get("X-Govisual-Replay") != "1" {
+		t.Fatal("replay marker header missing")
+	}
+}
+
+func TestHandlerGates(t *testing.T) {
+	body := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`
+
+	h := Handler(store.NewMemory(10))
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.RemoteAddr = "203.0.113.9:1234"
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("remote request: got %d, want 403", rec.Code)
+	}
+
+	h = Handler(store.NewMemory(10), WithToken("s3cret"))
+	req = httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.RemoteAddr = "127.0.0.1:1234"
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("missing token: got %d, want 401", rec.Code)
+	}
+
+	req = httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.RemoteAddr = "127.0.0.1:1234"
+	req.Header.Set("Authorization", "Bearer s3cret")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("authorized initialize: got %d body=%s", rec.Code, rec.Body.String())
+	}
+}

--- a/mcp/tools_read.go
+++ b/mcp/tools_read.go
@@ -1,0 +1,380 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/doganarif/govisual/v2/store"
+	sdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// defaultBodyBytes caps body excerpts in tool responses so a single call
+// can't flood an agent's context window. Callers can raise it per call.
+const defaultBodyBytes = 2048
+
+const defaultListLimit = 20
+
+type requestSummary struct {
+	ID       string `json:"id"`
+	Method   string `json:"method"`
+	Path     string `json:"path"`
+	Status   int    `json:"status"`
+	Duration int64  `json:"duration_ms"`
+	Time     string `json:"time"`
+	Error    string `json:"error,omitempty"`
+}
+
+func summarize(l *store.RequestLog) requestSummary {
+	return requestSummary{
+		ID:       l.ID,
+		Method:   l.Method,
+		Path:     l.Path,
+		Status:   l.StatusCode,
+		Duration: l.Duration,
+		Time:     l.Timestamp.Format("15:04:05.000"),
+		Error:    l.Error,
+	}
+}
+
+type requestDetail struct {
+	requestSummary
+	Host              string            `json:"host,omitempty"`
+	Query             string            `json:"query,omitempty"`
+	RequestHeaders    map[string]string `json:"request_headers,omitempty"`
+	ResponseHeaders   map[string]string `json:"response_headers,omitempty"`
+	RequestBody       string            `json:"request_body,omitempty"`
+	RequestBodyBytes  int               `json:"request_body_bytes,omitempty"`
+	ResponseBody      string            `json:"response_body,omitempty"`
+	ResponseBodyBytes int               `json:"response_body_bytes,omitempty"`
+	Logs              []store.LogEntry  `json:"logs,omitempty"`
+	SQLQueries        []store.SQLQuery  `json:"sql_queries,omitempty"`
+	HTTPCalls         []store.HTTPCall  `json:"http_calls,omitempty"`
+	Bottlenecks       []store.Bottleneck `json:"bottlenecks,omitempty"`
+	PanicStack        string            `json:"panic_stack,omitempty"`
+}
+
+func detail(l *store.RequestLog, maxBody int) requestDetail {
+	if maxBody <= 0 {
+		maxBody = defaultBodyBytes
+	}
+	d := requestDetail{
+		requestSummary:    summarize(l),
+		Host:              l.Host,
+		Query:             l.Query,
+		RequestHeaders:    flattenHeaders(l.RequestHeaders),
+		ResponseHeaders:   flattenHeaders(l.ResponseHeaders),
+		RequestBody:       truncate(l.RequestBody, maxBody),
+		RequestBodyBytes:  len(l.RequestBody),
+		ResponseBody:      truncate(l.ResponseBody, maxBody),
+		ResponseBodyBytes: len(l.ResponseBody),
+		Logs:              l.Logs,
+		PanicStack:        l.PanicStack,
+	}
+	if m := l.PerformanceMetrics; m != nil {
+		d.SQLQueries = m.SQLQueries
+		d.HTTPCalls = m.HTTPCalls
+		d.Bottlenecks = m.Bottlenecks
+	}
+	return d
+}
+
+func flattenHeaders(h map[string][]string) map[string]string {
+	if len(h) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(h))
+	for k, vs := range h {
+		out[k] = strings.Join(vs, ", ")
+	}
+	return out
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + fmt.Sprintf("... [%d more bytes; raise max_body_bytes to see more]", len(s)-n)
+}
+
+func isFailure(l *store.RequestLog) bool {
+	return l.StatusCode >= 400 || l.Error != ""
+}
+
+type listArgs struct {
+	Limit        int    `json:"limit,omitempty"`
+	Method       string `json:"method,omitempty"`
+	PathContains string `json:"path_contains,omitempty"`
+	StatusMin    int    `json:"status_min,omitempty"`
+	StatusMax    int    `json:"status_max,omitempty"`
+	ErrorsOnly   bool   `json:"errors_only,omitempty"`
+}
+
+type listResult struct {
+	Requests []requestSummary `json:"requests"`
+	Total    int              `json:"total_in_store"`
+	Note     string           `json:"note,omitempty"`
+}
+
+type idArgs struct {
+	ID           string `json:"id"`
+	MaxBodyBytes int    `json:"max_body_bytes,omitempty"`
+}
+
+type searchArgs struct {
+	Query string `json:"query"`
+	Limit int    `json:"limit,omitempty"`
+}
+
+type emptyArgs struct{}
+
+type statsResult struct {
+	Routes []routeStats `json:"routes"`
+}
+
+type reportResult struct {
+	Report string `json:"report"`
+}
+
+type routeStats struct {
+	Route      string `json:"route"`
+	Count      int    `json:"count"`
+	Errors     int    `json:"errors"`
+	P50Millis  int64  `json:"p50_ms"`
+	P95Millis  int64  `json:"p95_ms"`
+	LastSeenAt string `json:"last_seen"`
+}
+
+func registerReadTools(srv *sdk.Server, st store.Store) {
+	sdk.AddTool(srv, &sdk.Tool{
+		Name: "get_last_error",
+		Description: "Return the most recent failed request (status >= 400 or a recorded error/panic) " +
+			"with headers, body excerpts, logs, SQL queries and panic stack. Start here when debugging.",
+	}, func(ctx context.Context, req *sdk.CallToolRequest, args emptyArgs) (*sdk.CallToolResult, requestDetail, error) {
+		for _, l := range st.GetLatest(200) {
+			if isFailure(l) {
+				return nil, detail(l, defaultBodyBytes), nil
+			}
+		}
+		return nil, requestDetail{}, fmt.Errorf("no failed requests captured; %d requests in store", len(st.GetAll()))
+	})
+
+	sdk.AddTool(srv, &sdk.Tool{
+		Name: "list_requests",
+		Description: "List captured requests, newest first. Filters: method, path_contains, status_min/status_max, " +
+			"errors_only. limit defaults to 20. Returns compact summaries; use get_request for detail.",
+	}, func(ctx context.Context, req *sdk.CallToolRequest, args listArgs) (*sdk.CallToolResult, listResult, error) {
+		limit := args.Limit
+		if limit <= 0 {
+			limit = defaultListLimit
+		}
+		all := st.GetAll()
+		out := make([]requestSummary, 0, limit)
+		for _, l := range all {
+			if args.Method != "" && !strings.EqualFold(args.Method, l.Method) {
+				continue
+			}
+			if args.PathContains != "" && !strings.Contains(l.Path, args.PathContains) {
+				continue
+			}
+			if args.StatusMin > 0 && l.StatusCode < args.StatusMin {
+				continue
+			}
+			if args.StatusMax > 0 && l.StatusCode > args.StatusMax {
+				continue
+			}
+			if args.ErrorsOnly && !isFailure(l) {
+				continue
+			}
+			out = append(out, summarize(l))
+			if len(out) == limit {
+				break
+			}
+		}
+		res := listResult{Requests: out, Total: len(all)}
+		if len(out) == limit && len(all) > limit {
+			res.Note = "more matches may exist; refine filters or raise limit"
+		}
+		return nil, res, nil
+	})
+
+	sdk.AddTool(srv, &sdk.Tool{
+		Name: "get_request",
+		Description: "Full detail for one captured request by id: headers, body excerpts (capped by " +
+			"max_body_bytes, default 2048), logs, SQL queries, outbound HTTP calls, bottlenecks, panic stack.",
+	}, func(ctx context.Context, req *sdk.CallToolRequest, args idArgs) (*sdk.CallToolResult, requestDetail, error) {
+		l, ok := st.Get(args.ID)
+		if !ok {
+			return nil, requestDetail{}, fmt.Errorf("no request with id %q; it may have rolled out of the store", args.ID)
+		}
+		return nil, detail(l, args.MaxBodyBytes), nil
+	})
+
+	sdk.AddTool(srv, &sdk.Tool{
+		Name: "search_requests",
+		Description: "Substring search across path, query string, request/response bodies, and errors. " +
+			"Returns compact summaries, newest first.",
+	}, func(ctx context.Context, req *sdk.CallToolRequest, args searchArgs) (*sdk.CallToolResult, listResult, error) {
+		if args.Query == "" {
+			return nil, listResult{}, fmt.Errorf("query is required")
+		}
+		limit := args.Limit
+		if limit <= 0 {
+			limit = defaultListLimit
+		}
+		all := st.GetAll()
+		out := make([]requestSummary, 0, limit)
+		for _, l := range all {
+			if !matches(l, args.Query) {
+				continue
+			}
+			out = append(out, summarize(l))
+			if len(out) == limit {
+				break
+			}
+		}
+		return nil, listResult{Requests: out, Total: len(all)}, nil
+	})
+
+	sdk.AddTool(srv, &sdk.Tool{
+		Name: "get_stats",
+		Description: "Aggregate view of captured traffic: per-route request count, error count, p50/p95 " +
+			"latency. Use this to find slow or failing routes before drilling in.",
+	}, func(ctx context.Context, req *sdk.CallToolRequest, args emptyArgs) (*sdk.CallToolResult, statsResult, error) {
+		byRoute := map[string][]*store.RequestLog{}
+		for _, l := range st.GetAll() {
+			key := l.Method + " " + l.Path
+			byRoute[key] = append(byRoute[key], l)
+		}
+		out := make([]routeStats, 0, len(byRoute))
+		for route, logs := range byRoute {
+			durations := make([]int64, 0, len(logs))
+			errors := 0
+			last := logs[0].Timestamp
+			for _, l := range logs {
+				durations = append(durations, l.Duration)
+				if isFailure(l) {
+					errors++
+				}
+				if l.Timestamp.After(last) {
+					last = l.Timestamp
+				}
+			}
+			sort.Slice(durations, func(i, j int) bool { return durations[i] < durations[j] })
+			out = append(out, routeStats{
+				Route:      route,
+				Count:      len(logs),
+				Errors:     errors,
+				P50Millis:  percentile(durations, 50),
+				P95Millis:  percentile(durations, 95),
+				LastSeenAt: last.Format("15:04:05"),
+			})
+		}
+		sort.Slice(out, func(i, j int) bool { return out[i].Count > out[j].Count })
+		return nil, statsResult{Routes: out}, nil
+	})
+
+	sdk.AddTool(srv, &sdk.Tool{
+		Name: "get_debug_context",
+		Description: "Everything known about one request as a single readable report: request line, status, " +
+			"timing, headers, body excerpts, application logs, SQL queries, outbound calls, and panic stack. " +
+			"The one-call version of get_request for when you want the whole crime scene.",
+	}, func(ctx context.Context, req *sdk.CallToolRequest, args idArgs) (*sdk.CallToolResult, reportResult, error) {
+		l, ok := st.Get(args.ID)
+		if !ok {
+			return nil, reportResult{}, fmt.Errorf("no request with id %q", args.ID)
+		}
+		return nil, reportResult{Report: debugReport(l, args.MaxBodyBytes)}, nil
+	})
+}
+
+func matches(l *store.RequestLog, q string) bool {
+	q = strings.ToLower(q)
+	for _, s := range []string{l.Path, l.Query, l.RequestBody, l.ResponseBody, l.Error} {
+		if strings.Contains(strings.ToLower(s), q) {
+			return true
+		}
+	}
+	return false
+}
+
+func percentile(sorted []int64, p int) int64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	idx := len(sorted) * p / 100
+	if idx >= len(sorted) {
+		idx = len(sorted) - 1
+	}
+	return sorted[idx]
+}
+
+func debugReport(l *store.RequestLog, maxBody int) string {
+	if maxBody <= 0 {
+		maxBody = defaultBodyBytes
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s %s%s -> %d (%dms) at %s\n", l.Method, l.Path, querySuffix(l.Query), l.StatusCode, l.Duration, l.Timestamp.Format("15:04:05.000"))
+	if l.Error != "" {
+		fmt.Fprintf(&b, "ERROR: %s\n", l.Error)
+	}
+	if len(l.RequestHeaders) > 0 {
+		b.WriteString("\nRequest headers:\n")
+		writeHeaders(&b, l.RequestHeaders)
+	}
+	if l.RequestBody != "" {
+		fmt.Fprintf(&b, "\nRequest body (%d bytes):\n%s\n", len(l.RequestBody), truncate(l.RequestBody, maxBody))
+	}
+	if l.ResponseBody != "" {
+		fmt.Fprintf(&b, "\nResponse body (%d bytes):\n%s\n", len(l.ResponseBody), truncate(l.ResponseBody, maxBody))
+	}
+	if len(l.Logs) > 0 {
+		b.WriteString("\nApplication logs:\n")
+		for _, e := range l.Logs {
+			fmt.Fprintf(&b, "  %s [%s] %s", e.Time.Format("15:04:05.000"), e.Level, e.Message)
+			for k, v := range e.Attrs {
+				fmt.Fprintf(&b, " %s=%v", k, v)
+			}
+			b.WriteString("\n")
+		}
+	}
+	if m := l.PerformanceMetrics; m != nil {
+		if len(m.SQLQueries) > 0 {
+			fmt.Fprintf(&b, "\nSQL queries (%d):\n", len(m.SQLQueries))
+			for _, q := range m.SQLQueries {
+				fmt.Fprintf(&b, "  %s (%s, %d rows)", truncate(q.Query, 200), q.Duration, q.Rows)
+				if q.Error != "" {
+					fmt.Fprintf(&b, " ERROR: %s", q.Error)
+				}
+				b.WriteString("\n")
+			}
+		}
+		if len(m.HTTPCalls) > 0 {
+			fmt.Fprintf(&b, "\nOutbound HTTP calls (%d):\n", len(m.HTTPCalls))
+			for _, c := range m.HTTPCalls {
+				fmt.Fprintf(&b, "  %s %s -> %d (%s)\n", c.Method, c.URL, c.Status, c.Duration)
+			}
+		}
+		for _, bn := range m.Bottlenecks {
+			fmt.Fprintf(&b, "\nBottleneck [%s]: %s — %s\n", bn.Type, bn.Description, bn.Suggestion)
+		}
+	}
+	if l.PanicStack != "" {
+		fmt.Fprintf(&b, "\nPanic stack:\n%s\n", l.PanicStack)
+	}
+	return b.String()
+}
+
+func querySuffix(q string) string {
+	if q == "" {
+		return ""
+	}
+	return "?" + q
+}
+
+func writeHeaders(b *strings.Builder, h map[string][]string) {
+	for k, vs := range h {
+		fmt.Fprintf(b, "  %s: %s\n", k, strings.Join(vs, ", "))
+	}
+}

--- a/mcp/tools_replay.go
+++ b/mcp/tools_replay.go
@@ -1,0 +1,182 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/doganarif/govisual/v2/store"
+	sdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// replayClient deliberately has no redirect-following: a replay should show
+// what the app returned, not where a 302 leads.
+var replayClient = &http.Client{
+	Timeout: 30 * time.Second,
+	CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	},
+}
+
+type replayArgs struct {
+	ID      string            `json:"id"`
+	Method  string            `json:"method,omitempty"`
+	Path    string            `json:"path,omitempty"`
+	Headers map[string]string `json:"headers,omitempty"`
+	Body    string            `json:"body,omitempty"`
+}
+
+type replayResult struct {
+	Status     int    `json:"status"`
+	DurationMS int64  `json:"duration_ms"`
+	Body       string `json:"body"`
+	BodyBytes  int    `json:"body_bytes"`
+}
+
+type diffResult struct {
+	OriginalStatus int    `json:"original_status"`
+	ReplayStatus   int    `json:"replay_status"`
+	StatusChanged  bool   `json:"status_changed"`
+	BodyChanged    bool   `json:"body_changed"`
+	OriginalMS     int64  `json:"original_ms"`
+	ReplayMS       int64  `json:"replay_ms"`
+	ReplayBody     string `json:"replay_body,omitempty"`
+	Summary        string `json:"summary"`
+}
+
+func registerReplayTools(srv *sdk.Server, st store.Store, cfg *config) {
+	sdk.AddTool(srv, &sdk.Tool{
+		Name: "replay_request",
+		Description: "Re-send a captured request against the application, optionally overriding method, path, " +
+			"headers, or body. The destination host is fixed to the application — only the request shape is " +
+			"yours to change. Returns status, duration and a body excerpt.",
+	}, func(ctx context.Context, req *sdk.CallToolRequest, args replayArgs) (*sdk.CallToolResult, replayResult, error) {
+		l, ok := st.Get(args.ID)
+		if !ok {
+			return nil, replayResult{}, fmt.Errorf("no request with id %q", args.ID)
+		}
+		res, err := replay(ctx, cfg, l, args)
+		if err != nil {
+			return nil, replayResult{}, err
+		}
+		return nil, *res, nil
+	})
+
+	sdk.AddTool(srv, &sdk.Tool{
+		Name: "diff_replay",
+		Description: "Replay a captured request unchanged against the current code and diff the outcome " +
+			"against the original capture: status, body, timing. Use after changing code to verify a fix " +
+			"or check for regressions.",
+	}, func(ctx context.Context, req *sdk.CallToolRequest, args idArgs) (*sdk.CallToolResult, diffResult, error) {
+		l, ok := st.Get(args.ID)
+		if !ok {
+			return nil, diffResult{}, fmt.Errorf("no request with id %q", args.ID)
+		}
+		res, err := replay(ctx, cfg, l, replayArgs{ID: args.ID})
+		if err != nil {
+			return nil, diffResult{}, err
+		}
+
+		d := diffResult{
+			OriginalStatus: l.StatusCode,
+			ReplayStatus:   res.Status,
+			StatusChanged:  l.StatusCode != res.Status,
+			BodyChanged:    bodyChanged(l.ResponseBody, res.Body),
+			OriginalMS:     l.Duration,
+			ReplayMS:       res.DurationMS,
+		}
+		switch {
+		case d.StatusChanged:
+			d.Summary = fmt.Sprintf("status changed: %d -> %d", d.OriginalStatus, d.ReplayStatus)
+			d.ReplayBody = truncate(res.Body, defaultBodyBytes)
+		case d.BodyChanged:
+			d.Summary = "status unchanged, body differs"
+			d.ReplayBody = truncate(res.Body, defaultBodyBytes)
+		default:
+			d.Summary = "no change: same status, same body"
+		}
+		if l.ResponseBody == "" && res.Body != "" {
+			d.Summary += " (original capture has no response body; enable WithResponseBodyLogging for real body diffs)"
+		}
+		return nil, d, nil
+	})
+}
+
+func replay(ctx context.Context, cfg *config, l *store.RequestLog, args replayArgs) (*replayResult, error) {
+	base := cfg.baseURL
+	if base == "" {
+		if l.Host == "" {
+			return nil, fmt.Errorf("no replay base URL: configure WithBaseURL or capture requests with a Host")
+		}
+		base = "http://" + l.Host
+	}
+
+	method := l.Method
+	if args.Method != "" {
+		method = args.Method
+	}
+	path := l.Path
+	if args.Path != "" {
+		path = args.Path
+	}
+	url := strings.TrimSuffix(base, "/") + path
+	if l.Query != "" && args.Path == "" {
+		url += "?" + l.Query
+	}
+
+	body := l.RequestBody
+	if args.Body != "" {
+		body = args.Body
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url, strings.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("building replay request: %w", err)
+	}
+	for k, vs := range l.RequestHeaders {
+		for _, v := range vs {
+			req.Header.Add(k, v)
+		}
+	}
+	for k, v := range args.Headers {
+		req.Header.Set(k, v)
+	}
+	req.Header.Set("X-Govisual-Replay", "1")
+
+	start := time.Now()
+	resp, err := replayClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("replay failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("reading replay response: %w", err)
+	}
+
+	return &replayResult{
+		Status:     resp.StatusCode,
+		DurationMS: time.Since(start).Milliseconds(),
+		Body:       truncate(string(respBody), defaultBodyBytes),
+		BodyBytes:  len(respBody),
+	}, nil
+}
+
+// bodyChanged compares bodies structurally when both parse as JSON, so key
+// order and whitespace don't count as regressions.
+func bodyChanged(original, replayed string) bool {
+	if original == replayed {
+		return false
+	}
+	var a, b any
+	if json.Unmarshal([]byte(original), &a) == nil && json.Unmarshal([]byte(replayed), &b) == nil {
+		return !reflect.DeepEqual(a, b)
+	}
+	return true
+}

--- a/store/request.go
+++ b/store/request.go
@@ -11,6 +11,7 @@ type RequestLog struct {
 	ID                 string                   `json:"ID" bson:"_id"`
 	Timestamp          time.Time                `json:"Timestamp" bson:"timestamp"`
 	Method             string                   `json:"Method" bson:"method"`
+	Host               string                   `json:"Host,omitempty" bson:"host,omitempty"`
 	Path               string                   `json:"Path" bson:"path"`
 	Query              string                   `json:"Query" bson:"query"`
 	RequestHeaders     http.Header              `json:"RequestHeaders" bson:"request_headers"`
@@ -89,6 +90,7 @@ func NewRequestLog(req *http.Request) *RequestLog {
 		ID:             generateID(),
 		Timestamp:      time.Now(),
 		Method:         req.Method,
+		Host:           req.Host,
 		Path:           req.URL.Path,
 		Query:          req.URL.RawQuery,
 		RequestHeaders: scrubHeaders(req.Header),


### PR DESCRIPTION
New module github.com/doganarif/govisual/mcp (built on the official modelcontextprotocol/go-sdk) serving a streamable HTTP MCP endpoint over any govisual store. This is the 2.0 headline: an agent connected to it can see what actually happened at runtime and verify its own fixes.

Read tools: get_last_error (the debugging entry point — most recent 4xx/5xx/panic with full context), list_requests (filterable), get_request, search_requests, get_stats (per-route counts and p50/p95), get_debug_context (one-call crime scene: request line, headers, bodies, app logs, SQL, outbound calls, panic stack, as a readable report).

Action tools: replay_request (override method/path/headers/body; destination is pinned to the app so it's not an SSRF primitive) and diff_replay — re-run a captured request against current code and diff status and body (JSON-aware) against the original capture. Fix a bug, diff_replay the failing request, get "status changed: 500 -> 200".

Token discipline throughout: bounded list sizes, capped body excerpts with actual sizes reported and per-call overrides. Endpoint is loopback-only by default with optional bearer token; RequestLog now captures Host so replays can derive their target.

Tests drive every tool through a real MCP client over the SDK's in-memory transport, replay/diff against live httptest servers, plus gate tests. CI runs the module alongside the others.