### PR TITLE
Docs: bring the docs folder up to v2

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,8 +18,9 @@ Welcome to the GoVisual documentation. This documentation provides comprehensive
 
 ### Integration
 
+- [Claude Code / MCP](claude-code.md)
 - [OpenTelemetry Integration](opentelemetry.md)
-- [Storage Backends](storage-backends.md) - _New!_
+- [Storage Backends](storage-backends.md)
 
 ### Examples
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,8 +1,6 @@
 # API Reference
 
-This document provides a complete reference for the GoVisual API.
-
-## Core Functions
+## Core
 
 ### `Wrap`
 
@@ -10,38 +8,27 @@ This document provides a complete reference for the GoVisual API.
 func Wrap(handler http.Handler, opts ...Option) http.Handler
 ```
 
-Wraps an HTTP handler with GoVisual middleware to enable request visualization.
-
-**Parameters:**
-
-- `handler http.Handler`: The original HTTP handler to wrap
-- `opts ...Option`: Configuration options
-
-**Returns:**
-
-- `http.Handler`: The wrapped handler
+Wraps an HTTP handler with GoVisual middleware. Captures requests, serves the dashboard, and applies all options.
 
 **Example:**
 
 ```go
-wrapped := govisual.Wrap(originalHandler, options...)
+import "github.com/doganarif/govisual/v2"
+
+handler := govisual.Wrap(mux, govisual.WithRequestBodyLogging(true))
 ```
+
+---
 
 ## Configuration Options
 
-### Request Handling Options
-
-#### WithMaxRequests
+### `WithMaxRequests`
 
 ```go
 func WithMaxRequests(max int) Option
 ```
 
-Sets the maximum number of requests to store in memory.
-
-**Parameters:**
-
-- `max int`: Maximum number of requests to store
+Sets the capacity of the default in-memory store. Has no effect when a custom store is set via `WithStore`.
 
 **Example:**
 
@@ -49,17 +36,15 @@ Sets the maximum number of requests to store in memory.
 govisual.WithMaxRequests(500)
 ```
 
-#### WithDashboardPath
+---
+
+### `WithDashboardPath`
 
 ```go
 func WithDashboardPath(path string) Option
 ```
 
-Sets the URL path where the dashboard will be accessible.
-
-**Parameters:**
-
-- `path string`: URL path for the dashboard
+Sets the URL path for the dashboard. Trailing slashes are stripped.
 
 **Example:**
 
@@ -67,17 +52,15 @@ Sets the URL path where the dashboard will be accessible.
 govisual.WithDashboardPath("/__debug")
 ```
 
-#### WithRequestBodyLogging
+---
+
+### `WithRequestBodyLogging`
 
 ```go
 func WithRequestBodyLogging(enabled bool) Option
 ```
 
-Enables or disables logging of request bodies.
-
-**Parameters:**
-
-- `enabled bool`: Whether to log request bodies
+Enables or disables capture of request bodies.
 
 **Example:**
 
@@ -85,17 +68,15 @@ Enables or disables logging of request bodies.
 govisual.WithRequestBodyLogging(true)
 ```
 
-#### WithResponseBodyLogging
+---
+
+### `WithResponseBodyLogging`
 
 ```go
 func WithResponseBodyLogging(enabled bool) Option
 ```
 
-Enables or disables logging of response bodies.
-
-**Parameters:**
-
-- `enabled bool`: Whether to log response bodies
+Enables or disables capture of response bodies.
 
 **Example:**
 
@@ -103,204 +84,88 @@ Enables or disables logging of response bodies.
 govisual.WithResponseBodyLogging(true)
 ```
 
-#### WithIgnorePaths
+---
+
+### `WithIgnorePaths`
 
 ```go
 func WithIgnorePaths(patterns ...string) Option
 ```
 
-Sets path patterns to ignore from request logging.
-
-**Parameters:**
-
-- `patterns ...string`: Path patterns to ignore
+Adds path patterns to exclude from capture. Patterns follow `filepath.Match` syntax. A trailing slash treats the pattern as a prefix match.
 
 **Example:**
 
 ```go
-govisual.WithIgnorePaths("/health", "/metrics", "/static/*")
+govisual.WithIgnorePaths("/health", "/metrics", "/static/")
 ```
 
-#### WithMaxBodyBytes
+---
+
+### `WithMaxBodyBytes`
 
 ```go
 func WithMaxBodyBytes(n int) Option
 ```
 
-Caps the captured request and response body size. `0` uses the package default (1 MiB), a positive value sets an explicit cap in bytes, and a negative value disables the cap.
-
-**Parameters:**
-
-- `n int`: Body capture cap in bytes
+Caps the captured body size per request and response. `0` uses the package default (1 MiB). Positive values set an explicit cap. Negative values disable the cap entirely (not recommended for large downloads).
 
 **Example:**
 
 ```go
-govisual.WithMaxBodyBytes(64 << 10)
+govisual.WithMaxBodyBytes(64 << 10) // 64 KiB
 ```
 
-### Dashboard Security Options
+---
 
-#### WithLocalhostOnly
+### `WithSampleRate`
 
 ```go
-func WithLocalhostOnly() Option
+func WithSampleRate(rate float64) Option
 ```
 
-Restricts the dashboard to requests originating from a loopback address.
+Captures only the given fraction of requests (0..1). Values outside this range are clamped. Uncaptured requests pass through with no overhead. Useful when govisual wraps a high-traffic service and full capture would be noisy.
 
 **Example:**
 
 ```go
-govisual.WithLocalhostOnly()
+govisual.WithSampleRate(0.1) // capture 10% of requests
 ```
 
-#### WithBasicAuth
+---
+
+### `WithStore`
 
 ```go
-func WithBasicAuth(username, password string) Option
+func WithStore(s store.Store) Option
 ```
 
-Protects the dashboard with HTTP Basic Auth using a constant-time comparison.
-
-**Parameters:**
-
-- `username string`: Expected username
-- `password string`: Expected password
+Sets the storage backend for captured requests. Construct one from a storage module, then pass it here. Without this option, an in-memory store bounded by `WithMaxRequests` is used.
 
 **Example:**
 
 ```go
-govisual.WithBasicAuth("admin", "secret")
+import (
+    "github.com/doganarif/govisual/v2"
+    "github.com/doganarif/govisual/store/postgres"
+)
+
+pg, err := postgres.New(connStr, "govisual_requests", 500)
+// ...
+govisual.WithStore(pg)
 ```
 
-#### WithDashboardAuth
+---
 
-```go
-func WithDashboardAuth(fn DashboardAuth) Option
-```
-
-Installs a custom authentication function. It runs on every dashboard request and must return true to allow access.
-
-**Parameters:**
-
-- `fn DashboardAuth`: `func(*http.Request) bool`
-
-**Example:**
-
-```go
-govisual.WithDashboardAuth(func(r *http.Request) bool {
-    return r.Header.Get("X-Debug-Token") == "s3cret"
-})
-```
-
-#### WithReplayEnabled
-
-```go
-func WithReplayEnabled(enabled bool) Option
-```
-
-Enables the dashboard's replay endpoint. Disabled by default: the endpoint makes the server perform outbound HTTP requests (an SSRF primitive), so only enable it behind authentication and/or localhost-only access.
-
-**Parameters:**
-
-- `enabled bool`: Whether replay is allowed
-
-**Example:**
-
-```go
-govisual.WithReplayEnabled(true)
-```
-
-#### WithSystemInfo
-
-```go
-func WithSystemInfo(envAllowlist ...string) Option
-```
-
-Enables the dashboard's system-info endpoint. Environment variables are only exposed when their names are passed here; with no names, only memory and runtime info is shown.
-
-**Parameters:**
-
-- `envAllowlist ...string`: Environment variable names to expose
-
-**Example:**
-
-```go
-govisual.WithSystemInfo("GOPATH", "GOOS")
-```
-
-### Profiling Options
-
-#### WithProfiling
-
-```go
-func WithProfiling(enabled bool) Option
-```
-
-Enables per-request performance profiling (CPU, memory, goroutines).
-
-**Example:**
-
-```go
-govisual.WithProfiling(true)
-```
-
-#### WithProfileType
-
-```go
-func WithProfileType(profileType profiling.ProfileType) Option
-```
-
-Sets which profile types to collect. Defaults to all.
-
-**Example:**
-
-```go
-govisual.WithProfileType(profiling.ProfileCPU)
-```
-
-#### WithProfileThreshold
-
-```go
-func WithProfileThreshold(threshold time.Duration) Option
-```
-
-Only keeps profiles for requests slower than the threshold. Defaults to 10ms.
-
-**Example:**
-
-```go
-govisual.WithProfileThreshold(50 * time.Millisecond)
-```
-
-#### WithMaxProfileMetrics
-
-```go
-func WithMaxProfileMetrics(max int) Option
-```
-
-Sets the maximum number of profile records to keep. Defaults to 1000.
-
-**Example:**
-
-```go
-govisual.WithMaxProfileMetrics(500)
-```
-
-### Lifecycle Options
-
-#### WithShutdownContext
+### `WithShutdownContext`
 
 ```go
 func WithShutdownContext(ctx context.Context) Option
 ```
 
-Wires govisual's internal cleanup (storage backends, OpenTelemetry shutdown) to a caller-provided context: when the context is cancelled, govisual releases its resources. GoVisual does not install signal handlers — shutdown stays under the host application's control.
+Wires govisual's internal cleanup (closing the storage backend) to a caller-provided context. When the context is cancelled, govisual calls `Close()` on the store. This replaces the prior behavior of installing a global signal handler.
 
-**Parameters:**
-
-- `ctx context.Context`: Context whose cancellation triggers cleanup
+One goroutine blocks on `ctx.Done()` for the lifetime of the wrapped handler. Pass a cancellable context in tests to avoid goroutine leaks across test cases.
 
 **Example:**
 
@@ -311,159 +176,508 @@ defer stop()
 handler := govisual.Wrap(mux, govisual.WithShutdownContext(ctx))
 ```
 
-### Storage Options
+---
 
-#### WithMemoryStorage
+## Dashboard Security Options
+
+### `WithLocalhostOnly`
 
 ```go
-func WithMemoryStorage() Option
+func WithLocalhostOnly() Option
 ```
 
-Configures GoVisual to use in-memory storage (default).
+Restricts the dashboard to requests from loopback addresses. This is the default; the option exists to state intent explicitly.
 
 **Example:**
 
 ```go
-govisual.WithMemoryStorage()
+govisual.WithLocalhostOnly()
 ```
 
-#### WithPostgresStorage
+---
+
+### `WithAllowRemote`
 
 ```go
-func WithPostgresStorage(connStr string, tableName string) Option
+func WithAllowRemote() Option
 ```
 
-Configures GoVisual to use PostgreSQL storage.
-
-**Parameters:**
-
-- `connStr string`: PostgreSQL connection string
-- `tableName string`: Name of the table to use
+Allows non-loopback addresses to reach the dashboard. Pair with `WithBasicAuth` or `WithDashboardAuth` — an open dashboard exposes every captured request and response body to whoever can reach the port.
 
 **Example:**
 
 ```go
-govisual.WithPostgresStorage(
-    "postgres://user:password@localhost:5432/dbname?sslmode=disable",
-    "govisual_requests"
+govisual.WithAllowRemote()
+```
+
+---
+
+### `WithBasicAuth`
+
+```go
+func WithBasicAuth(username, password string) Option
+```
+
+Protects the dashboard with HTTP Basic Auth using a constant-time comparison.
+
+**Example:**
+
+```go
+govisual.WithBasicAuth("admin", "secret")
+```
+
+---
+
+### `WithDashboardAuth`
+
+```go
+func WithDashboardAuth(fn DashboardAuth) Option
+```
+
+Installs a custom authentication function that runs on every dashboard request. Return true to allow access, false to send HTTP 401. Implementations should use constant-time comparisons when checking secrets.
+
+`DashboardAuth` is `func(r *http.Request) bool`.
+
+**Example:**
+
+```go
+govisual.WithDashboardAuth(func(r *http.Request) bool {
+    return r.Header.Get("X-Debug-Token") == "s3cret"
+})
+```
+
+---
+
+### `WithReplayEnabled`
+
+```go
+func WithReplayEnabled(enabled bool) Option
+```
+
+Enables the dashboard's `/api/replay` endpoint. Disabled by default because the endpoint lets the server make arbitrary outbound HTTP requests (an SSRF primitive). Only enable it behind authentication and/or loopback-only access.
+
+**Example:**
+
+```go
+govisual.WithReplayEnabled(true)
+```
+
+---
+
+### `WithSystemInfo`
+
+```go
+func WithSystemInfo(envAllowlist ...string) Option
+```
+
+Enables the dashboard's `/api/system-info` endpoint (runtime stats, memory). Environment variables are only surfaced when their names are explicitly passed; with no arguments, no env vars are shown.
+
+**Example:**
+
+```go
+govisual.WithSystemInfo("GOPATH", "GOOS")
+```
+
+---
+
+## Profiling Options
+
+### `WithProfiling`
+
+```go
+func WithProfiling(enabled bool) Option
+```
+
+Enables per-request performance profiling. When enabled, each request captures CPU time, memory allocations, goroutine counts, SQL queries (via `WrapDriver`), and outbound HTTP calls (via `WrapTransport`).
+
+**Example:**
+
+```go
+govisual.WithProfiling(true)
+```
+
+---
+
+### `WithProfileType`
+
+```go
+func WithProfileType(profileType ProfileType) Option
+```
+
+Selects which profile kinds to collect. Constants are exported from the `govisual` package:
+
+- `govisual.ProfileCPU`
+- `govisual.ProfileMemory`
+- `govisual.ProfileGoroutine`
+- `govisual.ProfileAll` (default)
+
+**Example:**
+
+```go
+govisual.WithProfileType(govisual.ProfileCPU)
+```
+
+---
+
+### `WithProfileThreshold`
+
+```go
+func WithProfileThreshold(threshold time.Duration) Option
+```
+
+Only keeps profiles for requests that take longer than this duration. Defaults to 10ms.
+
+**Example:**
+
+```go
+govisual.WithProfileThreshold(50 * time.Millisecond)
+```
+
+---
+
+### `WithMaxProfileMetrics`
+
+```go
+func WithMaxProfileMetrics(max int) Option
+```
+
+Sets the maximum number of profile records to retain. Defaults to 1000.
+
+**Example:**
+
+```go
+govisual.WithMaxProfileMetrics(500)
+```
+
+---
+
+## Instrumentation Helpers
+
+### `WrapDriver`
+
+```go
+func WrapDriver(d driver.Driver) driver.Driver
+```
+
+Instruments a `database/sql` driver so queries executed with a request's context appear on that request's profile in the dashboard. Register the wrapped driver once and open the database through it. Requires `WithProfiling(true)` and queries must use the `*Context` variants with the request's context.
+
+**Example:**
+
+```go
+import (
+    "database/sql"
+    "github.com/doganarif/govisual/v2"
+    "github.com/lib/pq"
 )
+
+sql.Register("postgres+viz", govisual.WrapDriver(&pq.Driver{}))
+db, err := sql.Open("postgres+viz", dsn)
 ```
 
-#### WithRedisStorage
+---
+
+### `WrapTransport`
 
 ```go
-func WithRedisStorage(connStr string, ttlSeconds int) Option
+func WrapTransport(rt http.RoundTripper) http.RoundTripper
 ```
 
-Configures GoVisual to use Redis storage.
-
-**Parameters:**
-
-- `connStr string`: Redis connection string
-- `ttlSeconds int`: Time-to-live in seconds
+Instruments an `http.RoundTripper` so outbound HTTP calls made while handling a request appear on that request's profile. A nil `rt` wraps `http.DefaultTransport`. Requires `WithProfiling(true)` and outbound requests must carry the incoming request's context.
 
 **Example:**
 
 ```go
-govisual.WithRedisStorage("redis://localhost:6379/0", 86400)
+client := &http.Client{
+    Transport: govisual.WrapTransport(nil),
+}
+resp, err := client.Do(req.WithContext(r.Context()))
 ```
 
-### WithMongoDBStorage
+---
+
+### `SlogHandler`
 
 ```go
-func WithMongoDBStorage(uri, databaseName, collectionName string)
+func SlogHandler(base slog.Handler) slog.Handler
 ```
 
-Configures GoVisual to use MongoDB storage.
-
-**Parameters:**
-
-- `uri string`: MongoDB connection URI
-- `databaseName string`: Name of the database to use
-- `collectionName string`: Name of the collection to use
+Wraps a `slog.Handler` so log records emitted with a request's context are also attached to that request in the dashboard. Records logged outside a captured request pass through to the base handler untouched.
 
 **Example:**
 
 ```go
-govisual.WithMongoDBStorage("mongodb://user:password@localhost:27017", "your_database", "your_collection")
+import (
+    "log/slog"
+    "os"
+    "github.com/doganarif/govisual/v2"
+)
+
+logger := slog.New(govisual.SlogHandler(slog.NewJSONHandler(os.Stdout, nil)))
+
+// in a handler:
+logger.InfoContext(r.Context(), "cache miss", "key", key)
 ```
 
-### OpenTelemetry Options
+---
 
-#### WithOpenTelemetry
+### `Event`
 
 ```go
-func WithOpenTelemetry(enabled bool) Option
+func Event(ctx context.Context, name string, kv ...any)
 ```
 
-Enables or disables OpenTelemetry instrumentation.
-
-**Parameters:**
-
-- `enabled bool`: Whether to enable OpenTelemetry
+Annotates the current request with a named application event. The event appears in the request's log timeline and in the middleware trace when profiling is enabled. Key/value pairs follow slog convention. A call outside a captured request is a no-op.
 
 **Example:**
 
 ```go
-govisual.WithOpenTelemetry(true)
+govisual.Event(r.Context(), "cache miss", "key", key, "tier", "redis")
 ```
 
-#### WithServiceName
+---
+
+## store Package
+
+Import path: `github.com/doganarif/govisual/v2/store`
+
+### `Store` Interface
 
 ```go
-func WithServiceName(name string) Option
+type Store interface {
+    Add(log *RequestLog) error
+    Get(id string) (*RequestLog, bool)
+    GetAll() []*RequestLog
+    GetLatest(n int) []*RequestLog
+    Clear() error
+    Close() error
+}
 ```
 
-Sets the service name for OpenTelemetry.
+All storage backends implement this interface. `Add` returns an error so callers can surface storage failures. `Close` releases any open connections.
 
-**Parameters:**
+---
 
-- `name string`: Service name
+### `NewMemory`
+
+```go
+func NewMemory(capacity int) Store
+```
+
+Returns an in-memory ring buffer store. When the buffer is full, the oldest entry is overwritten. A capacity of zero or less defaults to 100.
 
 **Example:**
 
 ```go
-govisual.WithServiceName("my-service")
+st := store.NewMemory(500)
 ```
 
-#### WithServiceVersion
+---
+
+### `WithNotify`
 
 ```go
-func WithServiceVersion(version string) Option
+func WithNotify(s Store) *NotifyingStore
 ```
 
-Sets the service version for OpenTelemetry.
+Wraps any `Store` and signals subscribers after each successful `Add`. Use `Subscribe` to receive those signals.
 
-**Parameters:**
+```go
+func (n *NotifyingStore) Subscribe() (<-chan struct{}, func())
+```
 
-- `version string`: Service version
+The channel is buffered (size 1) so bursts coalesce into a single signal. Call the returned cancel function when done to unsubscribe.
 
 **Example:**
 
 ```go
-govisual.WithServiceVersion("1.0.0")
+ns := store.WithNotify(store.NewMemory(500))
+
+ch, cancel := ns.Subscribe()
+defer cancel()
+
+go func() {
+    for range ch {
+        // new request was captured
+    }
+}()
 ```
 
-#### WithOTelEndpoint
+---
+
+## Storage Backend Constructors
+
+Each backend is a separate Go module. Install with `go get` and pass the result to `WithStore`.
+
+### `postgres.New`
 
 ```go
-func WithOTelEndpoint(endpoint string) Option
+// module: github.com/doganarif/govisual/store/postgres
+func New(connStr, tableName string, capacity int) (*Store, error)
 ```
-
-Sets the OTLP endpoint for exporting telemetry data.
-
-**Parameters:**
-
-- `endpoint string`: OTLP endpoint
 
 **Example:**
 
 ```go
-govisual.WithOTelEndpoint("otel-collector:4317")
+pg, err := postgres.New("postgres://user:pass@localhost:5432/db?sslmode=disable", "govisual_requests", 500)
 ```
+
+---
+
+### `redis.New`
+
+```go
+// module: github.com/doganarif/govisual/store/redis
+func New(connStr string, capacity int, ttlSeconds int) (*Store, error)
+```
+
+`ttlSeconds` sets entry expiry; 0 defaults to 86400 (24 hours).
+
+**Example:**
+
+```go
+rdb, err := redis.New("redis://localhost:6379/0", 500, 86400)
+```
+
+---
+
+### `sqlite.New`
+
+```go
+// module: github.com/doganarif/govisual/store/sqlite
+func New(dbPath, tableName string, capacity int) (*Store, error)
+```
+
+Register a SQLite driver under the name `"sqlite3"` before calling this.
+
+**Example:**
+
+```go
+sq, err := sqlite.New("./govisual.db", "govisual_requests", 500)
+```
+
+---
+
+### `sqlite.NewWithDB`
+
+```go
+func NewWithDB(db *sql.DB, tableName string, capacity int) (*Store, error)
+```
+
+Use when your application already holds a `*sql.DB` opened with a SQLite driver. govisual does not call `Close` on a database it did not open.
+
+**Example:**
+
+```go
+sq, err := sqlite.NewWithDB(db, "govisual_requests", 500)
+```
+
+---
+
+### `mongodb.New`
+
+```go
+// module: github.com/doganarif/govisual/store/mongodb
+func New(uri, databaseName, collectionName string, capacity int) (*Store, error)
+```
+
+**Example:**
+
+```go
+mdb, err := mongodb.New("mongodb://localhost:27017", "govisual", "requests", 500)
+```
+
+---
+
+## telemetry Module
+
+Import path: `github.com/doganarif/govisual/telemetry`
+
+Install: `go get github.com/doganarif/govisual/telemetry`
+
+The telemetry module is separate so the OTel SDK and gRPC stay out of builds that don't use them.
+
+### `Wrap`
+
+```go
+func Wrap(handler http.Handler, cfg Config) (http.Handler, func(context.Context) error, error)
+```
+
+Initializes an exporter from `cfg` and returns the handler instrumented with tracing, plus a shutdown function that flushes pending spans. Wrap the application handler before passing to `govisual.Wrap` to keep the dashboard out of your traces.
+
+**Example:**
+
+```go
+import (
+    "github.com/doganarif/govisual/v2"
+    "github.com/doganarif/govisual/telemetry"
+)
+
+traced, shutdown, err := telemetry.Wrap(mux, telemetry.Config{
+    ServiceName:    "my-service",
+    ServiceVersion: "1.0.0",
+    Endpoint:       "localhost:4317",
+    Insecure:       true,
+    Exporter:       "otlp", // "otlp" | "stdout" | "noop"
+})
+if err != nil {
+    log.Fatal(err)
+}
+defer shutdown(context.Background())
+
+handler := govisual.Wrap(traced)
+```
+
+---
+
+### `Config`
+
+```go
+type Config struct {
+    ServiceName    string
+    ServiceVersion string
+    Endpoint       string // defaults to "localhost:4317" when Exporter is "otlp"
+    Insecure       bool
+    Exporter       string // "otlp" (default), "stdout", "noop"
+}
+```
+
+`Exporter` values:
+
+- `"otlp"` — OTLP gRPC exporter (default)
+- `"stdout"` — pretty-prints spans to stdout; useful for debugging
+- `"noop"` — discards all spans; useful for benchmarking tracing overhead
+
+---
+
+### `InitTracer`
+
+```go
+func InitTracer(ctx context.Context, cfg Config) (shutdown func(context.Context) error, err error)
+```
+
+Initializes the global OTel trace provider directly. `Wrap` calls this internally; use `InitTracer` when you want to set up the provider yourself and manage the middleware separately via `NewMiddleware`.
+
+---
+
+### `NewMiddleware`
+
+```go
+func NewMiddleware(handler http.Handler, serviceName, serviceVersion string) *Middleware
+```
+
+Returns an `http.Handler` that starts a span for each request using the already-configured global trace provider. Call after `InitTracer`.
+
+**Example:**
+
+```go
+shutdown, err := telemetry.InitTracer(ctx, cfg)
+// ...
+handler := telemetry.NewMiddleware(mux, "my-service", "1.0.0")
+```
+
+---
 
 ## Related Documentation
 
-- [Configuration Options](configuration.md) - Detailed configuration guide
-- [Storage Backends](storage-backends.md) - Storage backend documentation
-- [OpenTelemetry Integration](opentelemetry.md) - OpenTelemetry integration guide
+- [Configuration Options](configuration.md) - Options reference with examples
+- [Storage Backends](storage-backends.md) - Installing and configuring backends

--- a/docs/claude-code.md
+++ b/docs/claude-code.md
@@ -1,0 +1,79 @@
+# Using GoVisual with Claude Code
+
+GoVisual's MCP module gives a coding agent eyes into your running app: every captured request — headers, bodies, logs, SQL queries, panic stacks — becomes something the agent can query, replay, and diff.
+
+## Setup
+
+Mount the MCP endpoint next to your wrapped app:
+
+```go
+package main
+
+import (
+	"net/http"
+
+	gvmcp "github.com/doganarif/govisual/mcp"
+	"github.com/doganarif/govisual/v2"
+	"github.com/doganarif/govisual/v2/store"
+)
+
+func main() {
+	mux := http.NewServeMux()
+	// ... your routes ...
+
+	st := store.WithNotify(store.NewMemory(200))
+	app := govisual.Wrap(mux,
+		govisual.WithStore(st),
+		govisual.WithRequestBodyLogging(true),
+		govisual.WithResponseBodyLogging(true),
+	)
+
+	root := http.NewServeMux()
+	root.Handle("/mcp", gvmcp.Handler(st, gvmcp.WithBaseURL("http://localhost:8080")))
+	root.Handle("/", app)
+	http.ListenAndServe(":8080", root)
+}
+```
+
+Register it with Claude Code:
+
+```bash
+claude mcp add govisual --transport http http://localhost:8080/mcp
+```
+
+Sharing the same `store.WithNotify(...)` instance between `Wrap` and the MCP handler is what makes `await_request` push-fast; mounting `/mcp` outside `Wrap` keeps agent traffic out of your captures.
+
+## The debugging loop
+
+A typical session once the tools are connected:
+
+1. **`get_last_error`** — the most recent 4xx/5xx/panic with full context. The usual starting point.
+2. **`get_debug_context`** with the request id — request line, headers, bodies, application logs, SQL queries, outbound calls, and panic stack as one readable report.
+3. Fix the code, restart the app.
+4. **`diff_replay`** with the same id — replays the captured request against the running app and reports `status changed: 500 -> 200` (or that nothing changed).
+5. **`save_as_test`** — turn the request that used to fail into a regression test.
+
+For "why is this slow" instead of "why is this broken", start with **`get_stats`** (per-route p50/p95 and error counts), then `get_request` on a slow one — with `WithProfiling(true)` the SQL queries and outbound calls come with durations.
+
+To capture something that hasn't happened yet, call **`await_request`** with filters, then trigger the flow (curl, a test, a browser tool) — the tool returns the matching request the moment it's captured.
+
+## A CLAUDE.md snippet for your project
+
+Drop this into your repo's CLAUDE.md so the agent knows the tools exist and how to use them well:
+
+```markdown
+## Runtime debugging
+
+This app runs with GoVisual; the `govisual` MCP server exposes captured HTTP
+traffic. When debugging runtime behavior, prefer real captures over guessing:
+start with `get_last_error` or `get_stats`, read `get_debug_context` for the
+failing request, and verify fixes with `diff_replay` (expect
+"status changed" or "no change" — don't claim a fix without it).
+`clear_requests` before reproducing gives a clean capture.
+```
+
+## Security notes
+
+- The MCP endpoint answers loopback addresses only, unless `gvmcp.WithAllowRemote()` is set. Pair remote access with `gvmcp.WithToken("...")`.
+- `replay_request` can change the method, path, headers, and body — but never the destination. Replays always target your app (`WithBaseURL`), so the endpoint is not an SSRF primitive.
+- Sensitive headers (Authorization, Cookie, API keys) are redacted at capture time, before anything reaches the store or the agent.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,79 +1,65 @@
 # Configuration Options
 
-GoVisual provides numerous configuration options to customize its behavior to fit your specific needs.
-
-## Setting Configuration Options
-
-All configuration is done through option functions passed to the `govisual.Wrap()` function:
+All configuration is done through option functions passed to `govisual.Wrap()`.
 
 ```go
+import "github.com/doganarif/govisual/v2"
+
 handler := govisual.Wrap(
     originalHandler,
     option1,
     option2,
-    // ...more options
 )
 ```
 
 ## Available Options
 
-### Core Features
+### Core Options
 
-| Option                          | Description                           | Default    | Example                                           |
-| ------------------------------- | ------------------------------------- | ---------- | ------------------------------------------------- |
-| `WithMaxRequests(int)`          | Number of requests to store in memory | 100        | `govisual.WithMaxRequests(500)`                   |
-| `WithDashboardPath(string)`     | URL path for the dashboard            | "/\_\_viz" | `govisual.WithDashboardPath("/__debug")`          |
-| `WithRequestBodyLogging(bool)`  | Enable logging of request bodies      | false      | `govisual.WithRequestBodyLogging(true)`           |
-| `WithResponseBodyLogging(bool)` | Enable logging of response bodies     | false      | `govisual.WithResponseBodyLogging(true)`          |
-| `WithIgnorePaths(...string)`    | Paths to exclude from logging         | []         | `govisual.WithIgnorePaths("/health", "/metrics")` |
-| `WithMaxBodyBytes(int)`         | Cap on captured body size in bytes (0 = 1 MiB default, negative = unbounded) | 1 MiB | `govisual.WithMaxBodyBytes(64 << 10)` |
-| `WithShutdownContext(ctx)`      | Release storage and telemetry resources when the context is cancelled | none | `govisual.WithShutdownContext(ctx)` |
+| Option | Description | Default | Example |
+| --- | --- | --- | --- |
+| `WithMaxRequests(int)` | Capacity of the default in-memory store. Ignored when a custom store is set via `WithStore`. | 100 | `govisual.WithMaxRequests(500)` |
+| `WithDashboardPath(string)` | URL path for the dashboard | `/__viz` | `govisual.WithDashboardPath("/__debug")` |
+| `WithRequestBodyLogging(bool)` | Capture request bodies | false | `govisual.WithRequestBodyLogging(true)` |
+| `WithResponseBodyLogging(bool)` | Capture response bodies | false | `govisual.WithResponseBodyLogging(true)` |
+| `WithIgnorePaths(...string)` | Path patterns to exclude from capture | `[]` | `govisual.WithIgnorePaths("/health", "/metrics")` |
+| `WithMaxBodyBytes(int)` | Cap on captured body size in bytes. `0` = 1 MiB default, positive = explicit cap, negative = unbounded. | 1 MiB | `govisual.WithMaxBodyBytes(64 << 10)` |
+| `WithSampleRate(float64)` | Fraction of requests to capture (0..1). Uncaptured requests pass through untouched. | 1.0 | `govisual.WithSampleRate(0.1)` |
+| `WithStore(store.Store)` | Storage backend for captured requests. Omit to use an in-memory store bounded by `WithMaxRequests`. | in-memory | `govisual.WithStore(pg)` |
+| `WithShutdownContext(ctx)` | Cancel this context to release storage resources on shutdown. | none | `govisual.WithShutdownContext(ctx)` |
 
 ### Dashboard Security
 
-| Option                              | Description                                                        | Default  | Example                                        |
-| ----------------------------------- | ------------------------------------------------------------------ | -------- | ---------------------------------------------- |
-| `WithLocalhostOnly()`               | Only allow dashboard requests from loopback addresses              | off      | `govisual.WithLocalhostOnly()`                 |
-| `WithBasicAuth(user, pass)`         | Protect the dashboard with HTTP Basic Auth (constant-time compare) | off      | `govisual.WithBasicAuth("admin", "secret")`    |
-| `WithDashboardAuth(fn)`             | Custom auth check run on every dashboard request                   | off      | `govisual.WithDashboardAuth(myCheck)`          |
-| `WithReplayEnabled(bool)`           | Enable the request replay endpoint (SSRF primitive — keep it gated) | disabled | `govisual.WithReplayEnabled(true)`             |
-| `WithSystemInfo(...string)`         | Enable the system-info endpoint; env vars shown only if allowlisted | disabled | `govisual.WithSystemInfo("GOPATH")`            |
+The dashboard is loopback-only by default. `WithAllowRemote` opts out of that restriction; pair it with an auth option when you do.
+
+| Option | Description | Default | Example |
+| --- | --- | --- | --- |
+| `WithLocalhostOnly()` | Restrict the dashboard to loopback addresses. This is the default; the option exists to make intent explicit. | on | `govisual.WithLocalhostOnly()` |
+| `WithAllowRemote()` | Allow non-loopback addresses to reach the dashboard. Pair with `WithBasicAuth` or `WithDashboardAuth`. | off | `govisual.WithAllowRemote()` |
+| `WithBasicAuth(user, pass)` | Protect the dashboard with HTTP Basic Auth (constant-time compare) | off | `govisual.WithBasicAuth("admin", "secret")` |
+| `WithDashboardAuth(fn)` | Custom auth function run on every dashboard request; return true to allow | off | `govisual.WithDashboardAuth(myCheck)` |
+| `WithReplayEnabled(bool)` | Enable the request replay endpoint (SSRF primitive — keep it gated) | false | `govisual.WithReplayEnabled(true)` |
+| `WithSystemInfo(...string)` | Enable the system-info endpoint; env vars shown only if allowlisted | false | `govisual.WithSystemInfo("GOPATH")` |
 
 ### Profiling Options
 
-| Option                            | Description                                | Default | Example                                              |
-| --------------------------------- | ------------------------------------------ | ------- | ---------------------------------------------------- |
-| `WithProfiling(bool)`             | Enable per-request CPU/memory profiling    | false   | `govisual.WithProfiling(true)`                       |
-| `WithProfileType(type)`           | Which profiles to collect                  | all     | `govisual.WithProfileType(profiling.ProfileCPU)`     |
-| `WithProfileThreshold(duration)`  | Only keep profiles for requests slower than this | 10ms | `govisual.WithProfileThreshold(50 * time.Millisecond)` |
-| `WithMaxProfileMetrics(int)`      | Maximum number of profile records to keep  | 1000    | `govisual.WithMaxProfileMetrics(500)`                |
-
-### Storage Options
-
-| Option                                                     | Description                     | Default | Example                                                                                                          |
-| ---------------------------------------------------------  | ------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------- |
-| `WithMemoryStorage()`                                      | Use in-memory storage (default) | N/A     | `govisual.WithMemoryStorage()`                                                                                   |
-| `WithPostgresStorage(connStr, tableName)`                  | Use PostgreSQL storage          | N/A     | `govisual.WithPostgresStorage("postgres://user:pass@localhost:5432/db", "govisual_requests")`                    |
-| `WithRedisStorage(connStr, ttl)`                           | Use Redis storage               | N/A     | `govisual.WithRedisStorage("redis://localhost:6379/0", 86400)`                                                   |
-| `WithMongoDBStorage(uri, databaseName, collectionName)`    | Use MongoDB storage             | N/A     | `govisual.WithMongoDBStorage("mongodb://user:password@localhost:27017/", "your_database", "your_collection")`    |
-
-### OpenTelemetry Options
-
-| Option                       | Description                                | Default          | Example                                            |
-| ---------------------------- | ------------------------------------------ | ---------------- | -------------------------------------------------- |
-| `WithOpenTelemetry(bool)`    | Enable OpenTelemetry integration           | false            | `govisual.WithOpenTelemetry(true)`                 |
-| `WithServiceName(string)`    | Service name for OpenTelemetry             | "govisual"       | `govisual.WithServiceName("my-service")`           |
-| `WithServiceVersion(string)` | Service version for OpenTelemetry          | "dev"            | `govisual.WithServiceVersion("1.0.0")`             |
-| `WithOTelEndpoint(string)`   | OTLP endpoint for exporting telemetry data | "localhost:4317" | `govisual.WithOTelEndpoint("otel-collector:4317")` |
+| Option | Description | Default | Example |
+| --- | --- | --- | --- |
+| `WithProfiling(bool)` | Enable per-request CPU/memory/goroutine profiling | false | `govisual.WithProfiling(true)` |
+| `WithProfileType(ProfileType)` | Which profiles to collect: `ProfileCPU`, `ProfileMemory`, `ProfileGoroutine`, `ProfileAll` | `ProfileAll` | `govisual.WithProfileType(govisual.ProfileCPU)` |
+| `WithProfileThreshold(duration)` | Only keep profiles for requests slower than this | 10ms | `govisual.WithProfileThreshold(50 * time.Millisecond)` |
+| `WithMaxProfileMetrics(int)` | Maximum number of profile records to retain | 1000 | `govisual.WithMaxProfileMetrics(500)` |
 
 ## Configuration Examples
 
-### Basic Configuration
+### Basic Setup
 
 ```go
+import "github.com/doganarif/govisual/v2"
+
 handler := govisual.Wrap(
     mux,
-    govisual.WithMaxRequests(100),
+    govisual.WithMaxRequests(200),
     govisual.WithRequestBodyLogging(true),
     govisual.WithResponseBodyLogging(true),
 )
@@ -93,7 +79,6 @@ handler := govisual.Wrap(
 ```go
 handler := govisual.Wrap(
     mux,
-    govisual.WithLocalhostOnly(),
     govisual.WithBasicAuth("admin", "secret"),
     govisual.WithReplayEnabled(true),
     govisual.WithSystemInfo("GOPATH", "GOOS"),
@@ -103,47 +88,78 @@ handler := govisual.Wrap(
 ### PostgreSQL Storage
 
 ```go
+import (
+    "github.com/doganarif/govisual/v2"
+    "github.com/doganarif/govisual/store/postgres"
+)
+
+pg, err := postgres.New(
+    "postgres://user:password@localhost:5432/database?sslmode=disable",
+    "govisual_requests",
+    500, // capacity
+)
+if err != nil {
+    log.Fatal(err)
+}
+
 handler := govisual.Wrap(
     mux,
-    govisual.WithPostgresStorage(
-        "postgres://user:password@localhost:5432/database?sslmode=disable",
-        "govisual_requests"
-    ),
+    govisual.WithStore(pg),
 )
 ```
 
-### OpenTelemetry Integration
+### Sampling Busy Services
 
 ```go
+// Capture only 10% of requests.
 handler := govisual.Wrap(
     mux,
-    govisual.WithOpenTelemetry(true),
-    govisual.WithServiceName("my-api"),
-    govisual.WithServiceVersion("1.2.3"),
-    govisual.WithOTelEndpoint("otel-collector:4317"),
+    govisual.WithSampleRate(0.1),
+)
+```
+
+### Graceful Shutdown
+
+```go
+ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+defer stop()
+
+handler := govisual.Wrap(
+    mux,
+    govisual.WithShutdownContext(ctx),
 )
 ```
 
 ### Complete Example
 
 ```go
+import (
+    "github.com/doganarif/govisual/v2"
+    "github.com/doganarif/govisual/store/redis"
+)
+
+rdb, err := redis.New("redis://localhost:6379/0", 500, 86400)
+if err != nil {
+    log.Fatal(err)
+}
+
 handler := govisual.Wrap(
     mux,
-    govisual.WithMaxRequests(500),
+    govisual.WithStore(rdb),
     govisual.WithDashboardPath("/__debug"),
     govisual.WithRequestBodyLogging(true),
     govisual.WithResponseBodyLogging(true),
     govisual.WithIgnorePaths("/health", "/metrics", "/public/*"),
-    govisual.WithRedisStorage("redis://localhost:6379/0", 86400),
-    govisual.WithOpenTelemetry(true),
-    govisual.WithServiceName("user-service"),
-    govisual.WithServiceVersion("2.0.1"),
-    govisual.WithMongoDBStorage("mongodb://user:password@localhost:27017/", "your_database", "your_collection")
+    govisual.WithSampleRate(0.5),
+    govisual.WithBasicAuth("admin", "secret"),
+    govisual.WithProfiling(true),
+    govisual.WithProfileThreshold(25*time.Millisecond),
+    govisual.WithShutdownContext(ctx),
 )
 ```
 
 ## Related Documentation
 
-- [Storage Backends](storage-backends.md) - Detailed information about storage options
-- [OpenTelemetry Integration](opentelemetry.md) - In-depth guide for using OpenTelemetry
+- [Storage Backends](storage-backends.md) - Installing and configuring storage backends
+- [API Reference](api-reference.md) - Full API reference
 - [Quick Start Guide](quick-start.md) - Getting started with GoVisual

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,27 +4,24 @@ This guide covers installing GoVisual for your Go web applications.
 
 ## Requirements
 
-- Go 1.19 or higher
-- (Optional) PostgreSQL for persistent storage backend
-- (Optional) Redis for high-performance storage backend
-- (Optional) OpenTelemetry collector for telemetry data export
+- Go 1.24 or higher
+- (Optional) a database for persistent storage — each backend is its own module under `store/`
+- (Optional) an OpenTelemetry collector, via the `telemetry` module
 
 ## Using Go Modules (Recommended)
 
 The simplest way to install GoVisual is via Go modules:
 
 ```bash
-go get github.com/doganarif/govisual
+go get github.com/doganarif/govisual/v2
 ```
 
-## Manual Installation
-
-You can also manually clone the repository:
+The core module has no database drivers or gRPC. Add-ons install separately, only when you use them:
 
 ```bash
-git clone https://github.com/doganarif/govisual.git
-cd govisual
-go install
+go get github.com/doganarif/govisual/store/postgres   # or redis, sqlite, mongodb
+go get github.com/doganarif/govisual/telemetry        # OpenTelemetry export
+go get github.com/doganarif/govisual/mcp              # MCP server for coding agents
 ```
 
 ## Verifying Installation
@@ -37,7 +34,7 @@ package main
 import (
     "fmt"
     "net/http"
-    "github.com/doganarif/govisual"
+    "github.com/doganarif/govisual/v2"
 )
 
 func main() {

--- a/docs/opentelemetry.md
+++ b/docs/opentelemetry.md
@@ -1,13 +1,11 @@
 # Using GoVisual with OpenTelemetry
 
-GoVisual includes OpenTelemetry integration, allowing you to export telemetry data to your preferred backend.
+OpenTelemetry export lives in its own module, `github.com/doganarif/govisual/telemetry`, so the OTel SDK and its gRPC stack stay out of builds that don't use them.
 
 ## Prerequisites
 
-To use OpenTelemetry with GoVisual, you need:
-
 1. An OTLP-compatible collector running (such as Jaeger with OTLP enabled)
-2. GoVisual v1.0.0 or later
+2. The telemetry module: `go get github.com/doganarif/govisual/telemetry`
 
 ## Quick Start
 
@@ -24,31 +22,41 @@ docker run -d --name jaeger \
   jaegertracing/all-in-one:latest
 ```
 
-### 2. Enable OpenTelemetry in your Go application
+### 2. Wrap your handler
 
 ```go
 package main
 
 import (
+    "context"
+    "log"
     "net/http"
-    "github.com/doganarif/govisual"
+
+    "github.com/doganarif/govisual/telemetry"
+    "github.com/doganarif/govisual/v2"
 )
 
 func main() {
     mux := http.NewServeMux()
-
-    // Add your routes
     mux.HandleFunc("/api/users", userHandler)
 
-    // Enable GoVisual with OpenTelemetry
-    handler := govisual.Wrap(
-        mux,
-        govisual.WithOpenTelemetry(true),               // Enable OpenTelemetry
-        govisual.WithServiceName("my-service"),         // Set service name
-        govisual.WithServiceVersion("1.0.0"),           // Set service version
-        govisual.WithOTelEndpoint("localhost:4317"),    // OTLP exporter endpoint
-        govisual.WithRequestBodyLogging(true),          // Log request bodies
-        govisual.WithResponseBodyLogging(true),         // Log response bodies
+    // Trace the application handler. Wrapping the mux (not the final
+    // handler) keeps the govisual dashboard out of your traces.
+    traced, shutdown, err := telemetry.Wrap(mux, telemetry.Config{
+        ServiceName:    "my-service",
+        ServiceVersion: "1.0.0",
+        Endpoint:       "localhost:4317",
+        Insecure:       true,
+        Exporter:       telemetry.ExporterOTLP,
+    })
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer shutdown(context.Background())
+
+    handler := govisual.Wrap(traced,
+        govisual.WithRequestBodyLogging(true),
+        govisual.WithResponseBodyLogging(true),
     )
 
     http.ListenAndServe(":8080", handler)
@@ -57,69 +65,38 @@ func main() {
 
 ### 3. Run the example
 
-You can run the included example in the repository:
-
 ```bash
 cd cmd/examples/otel
-docker-compose up -d
+docker-compose up -d   # starts Jaeger
 go run main.go
 ```
 
-Then visit:
+Traces appear in the Jaeger UI at http://localhost:16686.
 
-- GoVisual dashboard: http://localhost:8080/\_\_viz
-- Jaeger UI: http://localhost:16686
+## Configuration
 
-## Configuration Options
+`telemetry.Config` fields:
 
-| Option                       | Description                            | Default            |
-| ---------------------------- | -------------------------------------- | ------------------ |
-| `WithOpenTelemetry(bool)`    | Enable OpenTelemetry integration       | `false`            |
-| `WithServiceName(string)`    | Set the service name for OpenTelemetry | `"govisual"`       |
-| `WithServiceVersion(string)` | Set the service version                | `"dev"`            |
-| `WithOTelEndpoint(string)`   | Set the OTLP exporter endpoint         | `"localhost:4317"` |
+| Field            | Description                                         | Default |
+| ---------------- | --------------------------------------------------- | ------- |
+| `ServiceName`    | Service name attached to every span                 |         |
+| `ServiceVersion` | Service version attached to every span              |         |
+| `Endpoint`       | OTLP gRPC endpoint                                  |         |
+| `Insecure`       | Skip TLS for the OTLP connection (local dev)        | `false` |
+| `Exporter`       | `ExporterOTLP`, `ExporterStdout`, or `ExporterNoop` |         |
 
-## How It Works
+`telemetry.Wrap` returns the instrumented handler and a shutdown function that flushes pending spans — call it on exit. For finer control, `telemetry.InitTracer(ctx, cfg)` sets up the exporter and `telemetry.NewMiddleware(handler, name, version)` instruments a handler separately.
 
-When OpenTelemetry is enabled:
+## Span propagation
 
-1. GoVisual initializes an OpenTelemetry tracer with the provided service name and version
-2. HTTP requests passing through GoVisual are automatically traced
-3. Trace data is exported to the configured OTLP endpoint
-4. The original GoVisual dashboard continues to work alongside OpenTelemetry
-
-## Adding Custom Spans
-
-You can add custom spans within your request handlers:
+The middleware extracts incoming W3C trace context headers, so spans join distributed traces started upstream. Handlers can start child spans with the global tracer:
 
 ```go
-func myHandler(w http.ResponseWriter, r *http.Request) {
-    // Get the context from the request (it contains the parent span from GoVisual)
-    ctx := r.Context()
-
-    // Start a new child span
-    ctx, span := otel.Tracer("my-service").Start(ctx, "my-operation")
-    defer span.End()
-
-    // Add attributes to the span
-    span.SetAttributes(attribute.String("user.id", "123"))
-
-    // Create nested spans for detailed operations
-    _, dbSpan := otel.Tracer("my-service").Start(ctx, "database.query")
-    // ... do database work
-    dbSpan.End()
-
-    // Respond to the client
-    w.Write([]byte("Hello, world!"))
-}
+ctx, span := otel.Tracer("my-service").Start(r.Context(), "database.query")
+defer span.End()
 ```
 
-## Troubleshooting
+## Related Documentation
 
-If you encounter issues:
-
-1. Check that your OpenTelemetry collector is running and accessible
-2. Ensure the endpoint in `WithOTelEndpoint()` matches your collector configuration
-3. Look for initialization errors in your application logs
-
-To see a full working example, refer to the `cmd/examples/otel` directory in the repository.
+- [Configuration Options](configuration.md)
+- [Quick Start Guide](quick-start.md)

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -12,7 +12,7 @@ package main
 import (
     "fmt"
     "net/http"
-    "github.com/doganarif/govisual"
+    "github.com/doganarif/govisual/v2"
 )
 
 func main() {

--- a/docs/storage-backends.md
+++ b/docs/storage-backends.md
@@ -1,62 +1,58 @@
-# Storage Backend Options
+# Storage Backends
 
-GoVisual supports multiple storage backends for persisting request logs, allowing you to choose the option that best fits your needs.
+GoVisual's core module (`github.com/doganarif/govisual/v2`) has no database drivers. Each storage backend lives in its own Go module under `store/`. Pull in only what you use.
 
-## Available Storage Backends
-
-### In-Memory Storage (Default)
-
-The in-memory storage keeps all request logs in memory. This is the simplest option and requires no additional setup, but logs will be lost when the application restarts.
+All backends implement `store.Store` and are passed to govisual via `WithStore`:
 
 ```go
-handler := govisual.Wrap(
-    mux,
-    govisual.WithMemoryStorage(), // Optional, this is the default
-)
+import "github.com/doganarif/govisual/v2"
+
+handler := govisual.Wrap(mux, govisual.WithStore(myStore))
 ```
 
-**Pros:**
+## In-Memory (Default)
 
-- No external dependencies
-- Fast performance
-- Zero configuration
+No install required. When no `WithStore` option is given, govisual creates an in-memory ring buffer bounded by `WithMaxRequests` (default 100).
 
-**Cons:**
-
-- Logs are lost on restart
-- Limited by available memory
-- Not suitable for long-term storage
-
-### PostgreSQL Storage
-
-For persistent storage of request logs, you can use PostgreSQL. This requires the `github.com/lib/pq` package.
+You can also create one explicitly and share it — for example, to expose it to the MCP server:
 
 ```go
-handler := govisual.Wrap(
-    mux,
-    govisual.WithPostgresStorage(
-        "postgres://user:password@localhost:5432/dbname?sslmode=disable", // Connection string
-        "govisual_requests"  // Table name (created automatically if it doesn't exist)
-    ),
-)
+import "github.com/doganarif/govisual/v2/store"
+
+st := store.NewMemory(500) // capacity
+handler := govisual.Wrap(mux, govisual.WithStore(st))
 ```
 
-**Pros:**
+Logs are lost on restart. Suitable for development.
 
-- Persistent storage
-- Logs retained across restarts
-- SQL querying capabilities
-- Reliable and mature storage
+## PostgreSQL
 
-**Cons:**
+```bash
+go get github.com/doganarif/govisual/store/postgres
+```
 
-- External dependency on PostgreSQL
-- Requires database setup and maintenance
-- Slightly higher latency than in-memory
+```go
+import (
+    "github.com/doganarif/govisual/v2"
+    "github.com/doganarif/govisual/store/postgres"
+)
+
+pg, err := postgres.New(
+    "postgres://user:password@localhost:5432/dbname?sslmode=disable", // connection string
+    "govisual_requests",                                               // table name
+    500,                                                               // capacity (rows kept)
+)
+if err != nil {
+    log.Fatal(err)
+}
+defer pg.Close()
+
+handler := govisual.Wrap(mux, govisual.WithStore(pg))
+```
+
+The table is created automatically on first use. The capacity limit is enforced by a periodic trim: once every 32 inserts, rows beyond the limit are deleted. The `github.com/lib/pq` driver is included transitively.
 
 **Schema:**
-
-The PostgreSQL adapter automatically creates a table with the following schema:
 
 ```sql
 CREATE TABLE IF NOT EXISTS govisual_requests (
@@ -78,71 +74,89 @@ CREATE TABLE IF NOT EXISTS govisual_requests (
 )
 ```
 
-### Redis Storage
+## Redis
 
-For high-performance storage with automatic expiration capabilities, you can use Redis. This requires the `github.com/go-redis/redis/v8` package.
-
-```go
-handler := govisual.Wrap(
-    mux,
-    govisual.WithRedisStorage(
-        "redis://localhost:6379/0", // Redis connection string
-        86400                       // TTL in seconds (24 hours)
-    ),
-)
+```bash
+go get github.com/doganarif/govisual/store/redis
 ```
 
-**Pros:**
-
-- Fast performance
-- Automatic time-to-live (TTL) support
-- Persistence options (RDB/AOF)
-- Smaller memory footprint than in-memory store
-
-**Cons:**
-
-- External dependency on Redis
-- Requires setup and maintenance
-- Less querying capabilities than SQL
-
-**Storage Structure:**
-
-The Redis adapter uses the following storage structure:
-
-- Each request log is stored as a JSON string with key `govisual:{id}`
-- A sorted set named `govisual:logs` is used to maintain order by timestamp
-- All keys automatically expire based on the configured TTL
-
-### SQLite Storage
-
-For lightweight, persistent local storage, you can use SQLite. This requires the github.com/ncruces/go-sqlite3 package.
-
 ```go
-handler := govisual.Wrap(
-    mux,
-    govisual.WithSQLiteStorage(
-        "./govisual.db",      // Path to the SQLite database file
-        "govisual_requests",  // Table name (created automatically if it doesn't exist)
-    ),
+import (
+    "github.com/doganarif/govisual/v2"
+    "github.com/doganarif/govisual/store/redis"
 )
+
+rdb, err := redis.New(
+    "redis://localhost:6379/0", // connection string
+    500,                        // capacity (number of entries kept)
+    86400,                      // TTL in seconds (24 hours; 0 = default 24h)
+)
+if err != nil {
+    log.Fatal(err)
+}
+defer rdb.Close()
+
+handler := govisual.Wrap(mux, govisual.WithStore(rdb))
 ```
 
-**Pros:**
+Each request is stored as a JSON string keyed by `govisual:{id}`. A sorted set named `govisual:logs` maintains order by timestamp. Keys expire automatically per the configured TTL. The `github.com/go-redis/redis/v8` client is included transitively.
 
-- Persistent local storage with no external server required
-- Zero configuration: just a .db file
-- Great for development, testing, and embedded environments
-- SQL querying capabilities
+## SQLite
 
-**Cons:**
+```bash
+go get github.com/doganarif/govisual/store/sqlite
+```
 
-- Not recommended for high concurrency or large-scale production use
-- Less scalable than PostgreSQL or Redis
-- Database file can grow quickly under heavy usage
+The SQLite module does not import a driver — it calls `sql.Open("sqlite3", path)` and expects the caller to have one registered. Import your preferred driver before calling `New`:
+
+```go
+import (
+    "github.com/doganarif/govisual/v2"
+    "github.com/doganarif/govisual/store/sqlite"
+    _ "github.com/ncruces/go-sqlite3/driver"
+    _ "github.com/ncruces/go-sqlite3/embed"
+)
+
+sq, err := sqlite.New(
+    "./govisual.db",     // path to the database file
+    "govisual_requests", // table name
+    500,                 // capacity
+)
+if err != nil {
+    log.Fatal(err)
+}
+defer sq.Close()
+
+handler := govisual.Wrap(mux, govisual.WithStore(sq))
+```
+
+### Reusing an Existing Connection
+
+If your application already opens a SQLite database, pass that `*sql.DB` to avoid double driver registration:
+
+```go
+import (
+    "database/sql"
+    "github.com/doganarif/govisual/v2"
+    "github.com/doganarif/govisual/store/sqlite"
+    _ "github.com/mattn/go-sqlite3"
+)
+
+db, err := sql.Open("sqlite3", "./app.db")
+if err != nil {
+    log.Fatal(err)
+}
+
+sq, err := sqlite.NewWithDB(db, "govisual_requests", 500)
+if err != nil {
+    log.Fatal(err)
+}
+// govisual does not close db when NewWithDB is used — you manage the lifecycle.
+
+handler := govisual.Wrap(mux, govisual.WithStore(sq))
+```
 
 **Schema:**
-
-The SQLite adapter automatically creates a table with the following schema:
 
 ```sql
 CREATE TABLE IF NOT EXISTS govisual_requests (
@@ -164,195 +178,79 @@ CREATE TABLE IF NOT EXISTS govisual_requests (
 )
 ```
 
-**Summary of usage:**
+## MongoDB
 
-- **For local persistence and simplicity**: SQLite is a great choice.
-- **For environments without external dependencies**: Just point to a .db file and use.
-
-### SQLite with Existing Connection
-
-If your application already uses SQLite with a driver like `github.com/mattn/go-sqlite3`, you may experience a conflict when using govisual's SQLite storage due to multiple driver registrations. To avoid this conflict, you can pass your existing database connection to govisual:
+```bash
+go get github.com/doganarif/govisual/store/mongodb
+```
 
 ```go
 import (
-    "database/sql"
-
-    "github.com/doganarif/govisual"
-    _ "github.com/mattn/go-sqlite3" // Your preferred SQLite driver
+    "github.com/doganarif/govisual/v2"
+    "github.com/doganarif/govisual/store/mongodb"
 )
 
-func main() {
-    // Create your own database connection
-    db, err := sql.Open("sqlite3", "./govisual.db")
-    if err != nil {
-        // Handle error
-    }
-    defer db.Close()
-
-    // Pass the existing connection to govisual
-    handler := govisual.Wrap(
-        mux,
-        govisual.WithSQLiteStorageDB(db, "govisual_requests"),
-    )
-
-    // Use the handler
-    http.ListenAndServe(":8080", handler)
+mdb, err := mongodb.New(
+    "mongodb://user:password@localhost:27017", // URI
+    "govisual",                                // database name
+    "requests",                                // collection name
+    500,                                       // capacity
+)
+if err != nil {
+    log.Fatal(err)
 }
+defer mdb.Close()
+
+handler := govisual.Wrap(mux, govisual.WithStore(mdb))
 ```
 
-**Pros:**
+A descending index on `timestamp` is created automatically. The `go.mongodb.org/mongo-driver/v2` client is included transitively.
 
-- Avoids "sql: Register called twice for driver sqlite3" panic
-- Allows you to use your preferred SQLite driver
-- Compatible with any existing SQLite connection
-- Share a single connection across your application
+## Choosing a Backend
 
-**Cons:**
+| Backend | Persists across restarts | External server | Notes |
+| --- | --- | --- | --- |
+| Memory | No | No | Default; zero setup |
+| SQLite | Yes | No | Good for single-process dev/test |
+| PostgreSQL | Yes | Yes | Use for long-term storage with SQL queries |
+| Redis | Yes (with AOF/RDB) | Yes | Use for high throughput; entries expire by TTL |
+| MongoDB | Yes | Yes | Use when you already run Mongo |
 
-- Requires you to manage the database connection lifecycle
-- You need to ensure your driver is compatible with govisual's requirements
+## Change Notification
 
-**When to use:**
-
-- When you're already using SQLite elsewhere in your application
-- When you want to avoid driver registration conflicts
-- When you need more control over the database connection
-
-### MongoDB Storage
-
-For document-based storage with high scalability, you can use MongoDB. This requires the `go.mongodb.org/mongo-driver/v2/mongo` package.
+`store.WithNotify` wraps any `store.Store` and signals subscribers after each `Add`. The dashboard uses it for live updates without polling:
 
 ```go
-handler := govisual.Wrap(
-    mux,
-    govisual.WithMongoDBStorage(
-        "mongodb://user:password@localhost:27017",  // MongoDB connection string
-        "govisual",                                 // Database name
-        "requests"                                  // Collection name
-    ),
-)
-```
+import "github.com/doganarif/govisual/v2/store"
 
-**Pros:**
+st := store.WithNotify(store.NewMemory(500))
 
-- Schema flexibility for varying request/response structures
-- High performance for read/write operations
-- Horizontal scalability through sharding
-- Rich querying capabilities for request analysis
-- Native JSON support for HTTP request/response data
-- Efficient handling of large document sizes
-- Built-in replication and high availability
+ch, cancel := st.Subscribe()
+defer cancel()
 
-**Cons:**
-
-- Higher memory usage compared to SQL databases
-- Requires separate MongoDB instance setup and maintenance
-- Eventually consistent by default (may affect real-time tracking)
-- Steeper learning curve for team operations
-- Higher hosting costs for production deployments
-- More complex backup procedures
-
-**Storage Structure:**
-
-The MongoDB adapter stores request logs in the following structure:
-
-```json
-{
-    "_id": "unique_request_id",
-    "timestamp": ISODate("2024-03-21T10:00:00Z"),
-    "method": "GET",
-    "path": "/api/users",
-    "query": "?page=1",
-    "request_headers": {
-        "Content-Type": "application/json",
-        "Authorization": "Bearer ..."
-    },
-    "response_headers": {
-        "Content-Type": "application/json"
-    },
-    "status_code": 200,
-    "duration": 150,
-    "request_body": "...",
-    "response_body": "...",
-    "error": null,
-    "middleware_trace": [...],
-    "route_trace": [...],
-    "created_at": ISODate("2024-03-21T10:00:00Z")
-}
-```
-
-**Connection String Format:**
-
-Standard MongoDB connection string format:
-```
-mongodb://[username:password@]host[:port][/database][?options]
-```
-
-Example:
-```
-mongodb://admin:password@localhost:27017/govisual?authSource=admin
-```
-
-**When to use:**
-
-- For applications with varying request/response structures
-- When high scalability is a requirement
-- In microservices architectures where eventual consistency is acceptable
-- When native JSON storage and querying are important
-- For distributed systems requiring horizontal scaling
-
-## Choosing a Storage Backend
-
-Here are some guidelines for choosing the appropriate storage backend:
-
-1. **Development/Testing:**
-
-   - In-memory storage (default) is typically sufficient
-   - No setup required, just works out of the box
-
-2. **Production/Longer-term storage:**
-
-   - PostgreSQL for permanent storage with SQL querying capabilities
-   - Redis for high-performance with TTL-based cleanup
-
-3. **High-traffic applications:**
-   - Redis for high throughput and lower memory footprint
-   - PostgreSQL with proper indexing for long-term storage and analytics
-
-## Connection String Formats
-
-### PostgreSQL
-
-Standard PostgreSQL connection string format:
-
-```
-postgres://[username]:[password]@[host]:[port]/[database_name]?[parameters]
-```
-
-Example:
-
-```
-postgres://postgres:password@localhost:5432/govisual?sslmode=disable
-```
-
-### Redis
-
-Standard Redis connection string format:
-
-```
-redis://[username]:[password]@[host]:[port]/[database_number]
-```
-
-Example:
-
-```
-redis://user:password@localhost:6379/0
+go func() {
+    for range ch {
+        // a new request was stored
+    }
+}()
 ```
 
 ## Graceful Shutdown
 
-GoVisual automatically handles graceful shutdown for all storage backends. When the application receives a shutdown signal (SIGTERM, SIGINT), it will properly close database connections.
+Pass a context via `WithShutdownContext`. When the context is cancelled, govisual calls `Close()` on the store:
 
-## Example
+```go
+ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+defer stop()
 
-For a complete example of all storage backends, see the [Multi-Storage Example](../cmd/examples/multistorage/README.md).
+handler := govisual.Wrap(
+    mux,
+    govisual.WithStore(pg),
+    govisual.WithShutdownContext(ctx),
+)
+```
+
+## Related Documentation
+
+- [Configuration Options](configuration.md) - Full options reference
+- [API Reference](api-reference.md) - store package API

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -130,7 +130,7 @@ Application becomes slow after integrating GoVisual.
 
 2. **Memory Issues**
    - Adjust TTL to clean up older entries faster
-   - Example: `govisual.WithRedisStorage("redis://localhost:6379/0", 3600) // 1 hour TTL`
+   - Example: `redis.New("redis://localhost:6379/0", 500, 3600) // 1 hour TTL`
 
 ## OpenTelemetry Integration Issues
 


### PR DESCRIPTION
The docs folder still described the v1 single-module API. This pass brings every page in line with what main actually ships:

- installation/quick-start: /v2 import path, add-on modules install separately
- configuration.md: current option set (WithStore, WithSampleRate, WithAllowRemote, security gates; storage/OTel options removed)
- storage-backends.md: module-per-backend design with real constructor signatures
- api-reference.md: full current API including WrapDriver/WrapTransport/SlogHandler/Event, the store package, and the telemetry module
- opentelemetry.md: telemetry-module workflow with composition order that keeps the dashboard untraced
- NEW claude-code.md: MCP setup, the get_last_error → get_debug_context → fix → diff_replay loop, a CLAUDE.md snippet for projects, and the security model

Docs only.