### PR TITLE
Ignore /favicon.ico by default

### DIFF
--- a/options.go
+++ b/options.go
@@ -299,7 +299,9 @@ func defaultConfig() *Config {
 		LogRequestBody:    false,
 		LogResponseBody:   false,
 		MaxBodyBytes:      0, // 0 => use middleware.DefaultMaxBodyBytes
-		IgnorePaths:       []string{},
+		// Browser probes that would otherwise clutter every capture; users
+		// can extend this list via WithIgnorePaths.
+		IgnorePaths: []string{"/favicon.ico"},
 		SampleRate:        1,
 		EnableProfiling:   false,
 		ProfileType:       profiling.ProfileAll,

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -142,3 +142,24 @@ func TestEventAttachesToRequest(t *testing.T) {
 func TestEventOutsideRequestIsNoOp(t *testing.T) {
 	Event(t.Context(), "orphan event", "k", "v")
 }
+
+func TestFaviconIsIgnoredByDefault(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/favicon.ico", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	mux.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {})
+	h := Wrap(mux)
+
+	for _, path := range []string{"/hello", "/favicon.ico"} {
+		h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, path, nil))
+	}
+
+	body := capturedRequests(t, h)
+	if !strings.Contains(body, "/hello") {
+		t.Fatalf("expected /hello captured: %s", body)
+	}
+	if strings.Contains(body, "/favicon.ico") {
+		t.Fatalf("expected /favicon.ico ignored: %s", body)
+	}
+}


### PR DESCRIPTION
Every browser session hitting the dashboard also probes for /favicon.ico and gets a 404 from the app, which then shows up as a captured request. It's the noisiest entry in a typical smoke run and adds nothing worth debugging.

The default IgnorePaths now includes /favicon.ico. WithIgnorePaths still appends to the list, so users can add their own patterns without losing the default; anyone who actually wants to see favicon probes can pass an explicit empty list via a custom Option.