### PR TITLE
Fix Logs and PanicStack being dropped by SQL backends

### DIFF
--- a/store/postgres/postgres.go
+++ b/store/postgres/postgres.go
@@ -59,6 +59,9 @@ func New(connStr, tableName string, capacity int) (*Store, error) {
 }
 
 func (s *Store) createTable() error {
+	// `extras` holds fields added in v2 (logs, panic stack, performance
+	// metrics) as a single JSONB blob so future capture fields don't need
+	// schema changes.
 	query := fmt.Sprintf(`
 		CREATE TABLE IF NOT EXISTS %s (
 			id TEXT PRIMARY KEY,
@@ -75,6 +78,7 @@ func (s *Store) createTable() error {
 			error TEXT,
 			middleware_trace JSONB,
 			route_trace JSONB,
+			extras JSONB,
 			created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 		)
 	`, s.tableName)
@@ -83,10 +87,51 @@ func (s *Store) createTable() error {
 		return err
 	}
 
+	// Add extras to pre-v2 tables. Postgres has IF NOT EXISTS on ADD COLUMN.
+	alter := fmt.Sprintf("ALTER TABLE %s ADD COLUMN IF NOT EXISTS extras JSONB", s.tableName)
+	if _, err := s.db.Exec(alter); err != nil {
+		log.Printf("govisual: ALTER TABLE for extras column failed: %v", err)
+	}
+
 	indexQuery := fmt.Sprintf("CREATE INDEX IF NOT EXISTS %s_timestamp_idx ON %s (timestamp DESC)",
 		s.tableName, s.tableName)
 	_, err := s.db.Exec(indexQuery)
 	return err
+}
+
+// extrasPayload holds capture fields added in v2 that share a single JSONB
+// column. Serialized to `extras` on write and unpacked on read.
+type extrasPayload struct {
+	Logs               []store.LogEntry          `json:"logs,omitempty"`
+	PanicStack         string                    `json:"panic_stack,omitempty"`
+	PerformanceMetrics *store.PerformanceMetrics `json:"performance_metrics,omitempty"`
+}
+
+func encodeExtras(l *store.RequestLog) string {
+	p := extrasPayload{Logs: l.Logs, PanicStack: l.PanicStack, PerformanceMetrics: l.PerformanceMetrics}
+	if len(p.Logs) == 0 && p.PanicStack == "" && p.PerformanceMetrics == nil {
+		return "{}"
+	}
+	data, err := json.Marshal(p)
+	if err != nil {
+		log.Printf("govisual: marshaling extras: %v", err)
+		return "{}"
+	}
+	return string(data)
+}
+
+func decodeExtras(s string, l *store.RequestLog) {
+	if s == "" || s == "{}" {
+		return
+	}
+	var p extrasPayload
+	if err := json.Unmarshal([]byte(s), &p); err != nil {
+		log.Printf("govisual: unmarshaling extras for %s: %v", l.ID, err)
+		return
+	}
+	l.Logs = p.Logs
+	l.PanicStack = p.PanicStack
+	l.PerformanceMetrics = p.PerformanceMetrics
 }
 
 // Add adds a new request log to the store
@@ -112,8 +157,8 @@ func (s *Store) Add(reqLog *store.RequestLog) error {
 		INSERT INTO %s (
 			id, timestamp, method, path, query, request_headers, response_headers,
 			status_code, duration, request_body, response_body, error,
-			middleware_trace, route_trace
-		) VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7::jsonb, $8, $9, $10, $11, $12, $13::jsonb, $14::jsonb)
+			middleware_trace, route_trace, extras
+		) VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7::jsonb, $8, $9, $10, $11, $12, $13::jsonb, $14::jsonb, $15::jsonb)
 	`, s.tableName)
 
 	_, err := s.db.Exec(
@@ -132,6 +177,7 @@ func (s *Store) Add(reqLog *store.RequestLog) error {
 		reqLog.Error,
 		middlewareTrace,
 		routeTrace,
+		encodeExtras(reqLog),
 	)
 	if err != nil {
 		return fmt.Errorf("postgres insert: %w", err)
@@ -183,7 +229,8 @@ func (s *Store) Get(id string) (*store.RequestLog, bool) {
 			COALESCE(response_headers::text, '{}'),
 			status_code, duration, request_body, response_body, error,
 			COALESCE(middleware_trace::text, '[]'),
-			COALESCE(route_trace::text, '{}')
+			COALESCE(route_trace::text, '{}'),
+			COALESCE(extras::text, '{}')
 		FROM %s
 		WHERE id = $1
 	`, s.tableName)
@@ -194,6 +241,7 @@ func (s *Store) Get(id string) (*store.RequestLog, bool) {
 		respHeadersStr  string
 		middlewareTrace string
 		routeTrace      string
+		extras          string
 	)
 
 	err := s.db.QueryRow(query, id).Scan(
@@ -211,6 +259,7 @@ func (s *Store) Get(id string) (*store.RequestLog, bool) {
 		&reqLog.Error,
 		&middlewareTrace,
 		&routeTrace,
+		&extras,
 	)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -224,6 +273,7 @@ func (s *Store) Get(id string) (*store.RequestLog, bool) {
 	unmarshalLogJSON(respHeadersStr, &reqLog.ResponseHeaders, "response_headers", reqLog.ID)
 	unmarshalLogJSON(middlewareTrace, &reqLog.MiddlewareTrace, "middleware_trace", reqLog.ID)
 	unmarshalLogJSON(routeTrace, &reqLog.RouteTrace, "route_trace", reqLog.ID)
+	decodeExtras(extras, &reqLog)
 
 	return &reqLog, true
 }
@@ -237,7 +287,8 @@ func (s *Store) GetAll() []*store.RequestLog {
 			COALESCE(response_headers::text, '{}'),
 			status_code, duration, request_body, response_body, error,
 			COALESCE(middleware_trace::text, '[]'),
-			COALESCE(route_trace::text, '{}')
+			COALESCE(route_trace::text, '{}'),
+			COALESCE(extras::text, '{}')
 		FROM %s
 		ORDER BY timestamp DESC
 	`, s.tableName)
@@ -254,7 +305,8 @@ func (s *Store) GetLatest(n int) []*store.RequestLog {
 			COALESCE(response_headers::text, '{}'),
 			status_code, duration, request_body, response_body, error,
 			COALESCE(middleware_trace::text, '[]'),
-			COALESCE(route_trace::text, '{}')
+			COALESCE(route_trace::text, '{}'),
+			COALESCE(extras::text, '{}')
 		FROM %s
 		ORDER BY timestamp DESC
 		LIMIT $1
@@ -280,6 +332,7 @@ func (s *Store) queryLogs(query string, args ...interface{}) []*store.RequestLog
 			respHeadersStr  string
 			middlewareTrace string
 			routeTrace      string
+			extras          string
 		)
 
 		if err := rows.Scan(
@@ -297,6 +350,7 @@ func (s *Store) queryLogs(query string, args ...interface{}) []*store.RequestLog
 			&reqLog.Error,
 			&middlewareTrace,
 			&routeTrace,
+			&extras,
 		); err != nil {
 			log.Printf("govisual: failed to scan row: %v", err)
 			continue
@@ -306,6 +360,7 @@ func (s *Store) queryLogs(query string, args ...interface{}) []*store.RequestLog
 		unmarshalLogJSON(respHeadersStr, &reqLog.ResponseHeaders, "response_headers", reqLog.ID)
 		unmarshalLogJSON(middlewareTrace, &reqLog.MiddlewareTrace, "middleware_trace", reqLog.ID)
 		unmarshalLogJSON(routeTrace, &reqLog.RouteTrace, "route_trace", reqLog.ID)
+		decodeExtras(extras, &reqLog)
 
 		logs = append(logs, &reqLog)
 	}

--- a/store/sqlite/schema_migration_test.go
+++ b/store/sqlite/schema_migration_test.go
@@ -1,0 +1,66 @@
+package sqlite
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/doganarif/govisual/v2/store"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func TestOpensAndUpgradesOldSchema(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	// Pre-v2 schema — no `extras` column.
+	_, err = db.Exec(`CREATE TABLE logs (
+		id TEXT PRIMARY KEY,
+		timestamp DATETIME,
+		method TEXT,
+		path TEXT,
+		query TEXT,
+		request_headers TEXT,
+		response_headers TEXT,
+		status_code INTEGER,
+		duration INTEGER,
+		request_body TEXT,
+		response_body TEXT,
+		error TEXT,
+		middleware_trace TEXT,
+		route_trace TEXT
+	)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Insert something with pre-v2 fields only.
+	_, err = db.Exec(`INSERT INTO logs (id, timestamp, method, path, query, request_headers, response_headers, status_code, duration, request_body, response_body, error, middleware_trace, route_trace)
+		VALUES ('old-1', ?, 'GET', '/pre-v2', '', '{}', '{}', 200, 0, '', '', '', '[]', '{}')`, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	s, err := NewWithDB(db, "logs", 10)
+	if err != nil {
+		t.Fatalf("open against old schema: %v", err)
+	}
+	got, ok := s.Get("old-1")
+	if !ok || got.Path != "/pre-v2" {
+		t.Fatalf("pre-v2 row missing after upgrade: %+v", got)
+	}
+	// A v2 row should now round trip.
+	s.Add(&store.RequestLog{
+		ID:         "new-1",
+		Timestamp:  time.Now(),
+		Method:     "GET",
+		Path:       "/v2",
+		StatusCode: 500,
+		PanicStack: "goroutine 1 [running]",
+		Logs:       []store.LogEntry{{Level: "ERROR", Message: "hi"}},
+	})
+	back, ok := s.Get("new-1")
+	if !ok || back.PanicStack == "" || len(back.Logs) != 1 {
+		t.Fatalf("v2 fields dropped on upgraded table: %+v", back)
+	}
+}

--- a/store/sqlite/sqlite.go
+++ b/store/sqlite/sqlite.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"strings"
 	"sync/atomic"
 
 	"github.com/doganarif/govisual/v2/store"
@@ -97,6 +98,9 @@ func NewWithDB(db *sql.DB, tableName string, capacity int) (*Store, error) {
 }
 
 func (s *Store) createTable() error {
+	// New tables carry an `extras` column for fields added in v2 (logs,
+	// panic stack, performance metrics) as a single JSON blob. That keeps
+	// the schema stable when we add more capture data later.
 	query := fmt.Sprintf(`
 		CREATE TABLE IF NOT EXISTS %s (
 			id TEXT PRIMARY KEY,
@@ -113,6 +117,7 @@ func (s *Store) createTable() error {
 			error TEXT,
 			middleware_trace TEXT,
 			route_trace TEXT,
+			extras TEXT,
 			created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 		)
 	`, s.tableName)
@@ -121,10 +126,56 @@ func (s *Store) createTable() error {
 		return err
 	}
 
+	// Best-effort ALTER for pre-v2 tables. SQLite reports "duplicate column
+	// name" if the column already exists; ignore that and keep going.
+	alter := fmt.Sprintf("ALTER TABLE %s ADD COLUMN extras TEXT", s.tableName)
+	if _, err := s.db.Exec(alter); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
+		log.Printf("govisual: ALTER TABLE for extras column failed: %v", err)
+	}
+
 	indexQuery := fmt.Sprintf("CREATE INDEX IF NOT EXISTS %s_timestamp_idx ON %s(timestamp DESC)",
 		s.tableName, s.tableName)
 	_, err := s.db.Exec(indexQuery)
 	return err
+}
+
+// extrasPayload holds the capture fields introduced in v2 that don't have
+// their own columns. Serialized to the `extras` JSON column.
+type extrasPayload struct {
+	Logs               []store.LogEntry          `json:"logs,omitempty"`
+	PanicStack         string                    `json:"panic_stack,omitempty"`
+	PerformanceMetrics *store.PerformanceMetrics `json:"performance_metrics,omitempty"`
+}
+
+func encodeExtras(l *store.RequestLog) string {
+	p := extrasPayload{
+		Logs:               l.Logs,
+		PanicStack:         l.PanicStack,
+		PerformanceMetrics: l.PerformanceMetrics,
+	}
+	if len(p.Logs) == 0 && p.PanicStack == "" && p.PerformanceMetrics == nil {
+		return ""
+	}
+	data, err := json.Marshal(p)
+	if err != nil {
+		log.Printf("govisual: marshaling extras: %v", err)
+		return ""
+	}
+	return string(data)
+}
+
+func decodeExtras(s string, l *store.RequestLog) {
+	if s == "" {
+		return
+	}
+	var p extrasPayload
+	if err := json.Unmarshal([]byte(s), &p); err != nil {
+		log.Printf("govisual: unmarshaling extras for %s: %v", l.ID, err)
+		return
+	}
+	l.Logs = p.Logs
+	l.PanicStack = p.PanicStack
+	l.PerformanceMetrics = p.PerformanceMetrics
 }
 
 func (s *Store) Add(reqLog *store.RequestLog) error {
@@ -149,8 +200,8 @@ func (s *Store) Add(reqLog *store.RequestLog) error {
 		INSERT OR REPLACE INTO %s (
 			id, timestamp, method, path, query, request_headers, response_headers,
 			status_code, duration, request_body, response_body, error,
-			middleware_trace, route_trace
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			middleware_trace, route_trace, extras
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`, s.tableName)
 
 	_, err := s.db.Exec(
@@ -169,6 +220,7 @@ func (s *Store) Add(reqLog *store.RequestLog) error {
 		reqLog.Error,
 		middlewareTrace,
 		routeTrace,
+		encodeExtras(reqLog),
 	)
 	if err != nil {
 		return fmt.Errorf("sqlite insert: %w", err)
@@ -205,7 +257,8 @@ func (s *Store) Get(id string) (*store.RequestLog, bool) {
 			COALESCE(response_headers, '{}'),
 			status_code, duration, request_body, response_body, error,
 			COALESCE(middleware_trace, '[]'),
-			COALESCE(route_trace, '{}')
+			COALESCE(route_trace, '{}'),
+			COALESCE(extras, '')
 		FROM %s
 		WHERE id = ?
 	`, s.tableName)
@@ -216,6 +269,7 @@ func (s *Store) Get(id string) (*store.RequestLog, bool) {
 		respHeadersStr  string
 		middlewareTrace string
 		routeTrace      string
+		extras          string
 	)
 
 	err := s.db.QueryRow(query, id).Scan(
@@ -233,6 +287,7 @@ func (s *Store) Get(id string) (*store.RequestLog, bool) {
 		&reqLog.Error,
 		&middlewareTrace,
 		&routeTrace,
+		&extras,
 	)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -246,6 +301,7 @@ func (s *Store) Get(id string) (*store.RequestLog, bool) {
 	unmarshalLogJSON(respHeadersStr, &reqLog.ResponseHeaders, "response_headers", reqLog.ID)
 	unmarshalLogJSON(middlewareTrace, &reqLog.MiddlewareTrace, "middleware_trace", reqLog.ID)
 	unmarshalLogJSON(routeTrace, &reqLog.RouteTrace, "route_trace", reqLog.ID)
+	decodeExtras(extras, &reqLog)
 
 	return &reqLog, true
 }
@@ -258,7 +314,8 @@ func (s *Store) GetAll() []*store.RequestLog {
 			COALESCE(response_headers, '{}'),
 			status_code, duration, request_body, response_body, error,
 			COALESCE(middleware_trace, '[]'),
-			COALESCE(route_trace, '{}')
+			COALESCE(route_trace, '{}'),
+			COALESCE(extras, '')
 		FROM %s
 		ORDER BY timestamp DESC
 	`, s.tableName)
@@ -274,7 +331,8 @@ func (s *Store) GetLatest(n int) []*store.RequestLog {
 			COALESCE(response_headers, '{}'),
 			status_code, duration, request_body, response_body, error,
 			COALESCE(middleware_trace, '[]'),
-			COALESCE(route_trace, '{}')
+			COALESCE(route_trace, '{}'),
+			COALESCE(extras, '')
 		FROM %s
 		ORDER BY timestamp DESC
 		LIMIT ?
@@ -299,6 +357,7 @@ func (s *Store) queryLogs(query string, args ...interface{}) []*store.RequestLog
 			respHeadersStr  string
 			middlewareTrace string
 			routeTrace      string
+			extras          string
 		)
 		if err := rows.Scan(
 			&reqLog.ID,
@@ -315,6 +374,7 @@ func (s *Store) queryLogs(query string, args ...interface{}) []*store.RequestLog
 			&reqLog.Error,
 			&middlewareTrace,
 			&routeTrace,
+			&extras,
 		); err != nil {
 			log.Printf("govisual: failed to scan row: %v", err)
 			continue
@@ -324,6 +384,7 @@ func (s *Store) queryLogs(query string, args ...interface{}) []*store.RequestLog
 		unmarshalLogJSON(respHeadersStr, &reqLog.ResponseHeaders, "response_headers", reqLog.ID)
 		unmarshalLogJSON(middlewareTrace, &reqLog.MiddlewareTrace, "middleware_trace", reqLog.ID)
 		unmarshalLogJSON(routeTrace, &reqLog.RouteTrace, "route_trace", reqLog.ID)
+		decodeExtras(extras, &reqLog)
 
 		logs = append(logs, &reqLog)
 	}

--- a/store/storetest/storetest.go
+++ b/store/storetest/storetest.go
@@ -48,4 +48,47 @@ func Run(t *testing.T, s store.Store) {
 	if len(s.GetAll()) != 0 {
 		t.Error("expected no logs after Clear")
 	}
+
+	// Every v2 capture field must survive a round trip. Backends added their
+	// own columns for these historically; forgetting to persist Logs or
+	// PanicStack is a real regression, hence the explicit contract.
+	rich := &store.RequestLog{
+		ID:         "rich-1",
+		Timestamp:  time.Now(),
+		Method:     "POST",
+		Path:       "/api/things",
+		StatusCode: 500,
+		Error:      "panic: kaboom",
+		PanicStack: "goroutine 1 [running]:\nmain.boom()\n\t/tmp/x.go:5",
+		Logs: []store.LogEntry{
+			{Time: time.Now(), Level: "ERROR", Message: "before panic", Attrs: map[string]any{"k": "v"}},
+		},
+		PerformanceMetrics: &store.PerformanceMetrics{
+			RequestID:  "rich-1",
+			Duration:   42 * time.Millisecond,
+			SQLQueries: []store.SQLQuery{{Query: "SELECT 1", Duration: time.Millisecond, Rows: 1}},
+			HTTPCalls:  []store.HTTPCall{{Method: "GET", URL: "http://x", Duration: time.Millisecond, Status: 200}},
+		},
+	}
+	if err := s.Add(rich); err != nil {
+		t.Fatalf("Add rich: %v", err)
+	}
+	back, ok := s.Get("rich-1")
+	if !ok {
+		t.Fatal("expected rich-1 after Add")
+	}
+	if back.PanicStack == "" {
+		t.Error("PanicStack dropped by store round trip")
+	}
+	if len(back.Logs) != 1 || back.Logs[0].Message != "before panic" {
+		t.Errorf("Logs dropped by store round trip: %+v", back.Logs)
+	}
+	if back.PerformanceMetrics == nil ||
+		len(back.PerformanceMetrics.SQLQueries) != 1 ||
+		len(back.PerformanceMetrics.HTTPCalls) != 1 {
+		t.Errorf("PerformanceMetrics dropped or trimmed: %+v", back.PerformanceMetrics)
+	}
+	if err := s.Clear(); err != nil {
+		t.Errorf("Clear after rich: %v", err)
+	}
 }


### PR DESCRIPTION
The SQLite and Postgres backends persist request logs into explicit columns. Layer 1 added Logs and PanicStack to the RequestLog model, and PerformanceMetrics on top, but the SQL backends' schemas and INSERT/SELECT statements never picked them up — so anyone using persistent storage lost the panic stack and per-request slog capture after a restart. Redis and MongoDB serialize the whole struct so they were unaffected.

I found this doing a full end-to-end smoke of the v2 build against a fresh SQLite-backed app — the Panic entry in the API response came back with PanicStack: null.

Fix: an `extras` JSON/JSONB column stores the v2 additions (Logs, PanicStack, PerformanceMetrics) together. Both createTable and an ALTER TABLE-on-open upgrade path are covered — SQLite ignores the duplicate-column error, Postgres uses IF NOT EXISTS. Reads COALESCE to an empty object.

I also promoted the storetest package into a real contract: it now round-trips every v2 capture field and asserts they come back. All five stores (memory, sqlite, postgres via CI, mongodb via CI, redis) pass. Added a schema-migration test that starts a v0.x-shape table, opens it with v2, and verifies both the pre-v2 row survives and v2 fields round trip on the upgraded schema.

Better a slightly-wider fix now than tagging v2.0.0 with a persistence regression.